### PR TITLE
Making our registration JSON endpoint return the account's status.

### DIFF
--- a/registration.md
+++ b/registration.md
@@ -253,13 +253,8 @@ This describes how we handle the response, after an account has been
 successfully created.
 
 * If the request is `Accept: application/json`, the response should be status
-  200 with a JSON body.  The body should only contain a single JSON field:
-  `status`.  It should look something like this:
-
-```json
-{
-  "status": "VERIFIED"
-}
+  200 with a JSON body.  The body should be the account object that was returned
+  from the account creation call.
 ```
 
 * If the request is `Accept: text/html`, and..
@@ -270,6 +265,8 @@ successfully created.
     * `False`: inform the user that their account has been created and they may
       now login
   * The newly created account status is UNVERIFIED, then render a view which
-  tells the user to check their email for a verification link
+  tells the user to check their email for a verification link.  This view should
+  containa  link to the VERIFY view, reading "didn't get the email? click here
+  to re-send the message."
 
 <a href="#top">Back to Top</a>

--- a/registration.md
+++ b/registration.md
@@ -253,7 +253,14 @@ This describes how we handle the response, after an account has been
 successfully created.
 
 * If the request is `Accept: application/json`, the response should be status
-  200 with an empty body.
+  200 with a JSON body.  The body should only contain a single JSON field:
+  `status`.  It should look something like this:
+
+```json
+{
+  "status": "VERIFIED"
+}
+```
 
 * If the request is `Accept: text/html`, and..
   * The newly created account's status is ENABLED and [AUTO_LOGIN](#AUTO_LOGIN)


### PR DESCRIPTION
This allows for front-end frameworks like angular / etc to know the status of
the account, since they can't read the cookies (httpOnly).

Robert and I bumped into this yesterday when working on angular. We couldn't find another way to do it without returning this.
