### PR TITLE
Enabling features by default

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -1,0 +1,13 @@
+<a name="#top">Back to Top</a>
+
+# Configuration Options
+
+The framework integration has a set of configuration options that are specific
+to web applications, this configuration extends the configuration for the
+underlying SDK.
+
+The entire configuration reference can be found in the
+[web-config.yaml](web-config.yaml) file.
+
+For detailed descriptions of each configuration option, please refer to the
+relevant feature documentation file in this repository.

--- a/email-verification.md
+++ b/email-verification.md
@@ -38,12 +38,23 @@ framework language (*e.g. to camel case, or not*)?  Is not specified here.
 ```json
 {
   "verifyEmail": {
+    "enabled": false,
     "autoLogin": false,
     "uri": "/verify",
     "nextUri": "/"
   }
 }
 ```
+
+
+### <a name="enabled"></a> enabled
+
+If enabled, the framework should handle requests for the `uri`.  This option
+is disabled by default, but the configuration parser should enable it if the
+default account store of the provided application has the email verification
+workflow enabled
+
+<a href="#top">Back to Top</a>
 
 
 ### <a name="autoLogin"></a> autoLogin

--- a/login.md
+++ b/login.md
@@ -7,9 +7,9 @@
 
 * [Options](#Options)
   * [AUTO_LOGIN](#AUTO_LOGIN)
-  * [ENABLE_LOGIN](#ENABLE_LOGIN)
+  * [ENABLED](#ENABLED)
   * [REDIRECT_URL](#REDIRECT_URL)
-  * [LOGIN_URL](#LOGIN_URL)
+  * [URI](#URI)
   * [GOOGLE_CALLBACK_URL](#GOOGLE_CALLBACK_URL)
   * [FACEBOOK_CALLBACK_URL](#FACEBOOK_CALLBACK_URL)
   * [GITHUB_CALLBACK_URL](#GITHUB_CALLBACK_URL)
@@ -24,8 +24,8 @@
 This document describes the endpoints and logic that must exist in order to
 facilitate self-service login of user accounts.
 
-If enabled via the `ENABLE_LOGIN` option, our library MUST intercept
-incoming requests for the `LOGIN_URL` and either render a login form (GET) or
+If enabled via the `ENABLED` option, our library MUST intercept
+incoming requests for the `URI` and either render a login form (GET) or
 handle a POST request from the login form.
 
 GET requests should serve an HTML Page OR Single Page Application, in either
@@ -54,9 +54,9 @@ framework language (e.g. to camel case, or not)? Is not specified here.
 | Option                           | Default Value       |
 | -------------------------------- |---------------------|
 | AUTO_REDIRECT                    | True                |
-| ENABLE_LOGIN                     | False               |
+| ENABLED                          | True                |
 | REDIRECT_URL                     | /                   |
-| LOGIN_URL                        | /login              |
+| URI                              | /login              |
 | GOOGLE_CALLBACK_URL              | /callbacks/google   |
 | FACEBOOK_CALLBACK_URL            | /callbacks/facebook |
 | GITHUB_CALLBACK_URL              | /callbacks/github   |
@@ -77,17 +77,17 @@ menu bar).
 <a href="#top">Back to Top</a>
 
 
-#### <a name="ENABLE_LOGIN"></a> ENABLE_LOGIN
+#### <a name="ENABLED"></a> ENABLED
 
 If `True` this feature will be enabled and our library will intercept requests
-at the [LOGIN_URL](#LOGIN_URL).  When the application server starts, we will
+at the [URI](#URI).  When the application server starts, we will
 query the user's Stormpath Application to discover what Account Store Mappings
 are available.  We will then pre-load these so that the login page displays all
 available forms of login (*this might include username / email and password
 login, Facebook Login, Google Login, etc.*).
 
 If `False` this feature is disabled and the base framework will be responsible
-for the [LOGIN_URL](#LOGIN_URL), likely resulting in a 404 Not Found error.
+for the [URI](#URI), likely resulting in a 404 Not Found error.
 
 **NOTE**: If this feature is enabled, and no Account Stores are mapped to this
 Application -- we will throw an error during initialization since there are no
@@ -100,12 +100,12 @@ possible ways for a user to authenticate.
 #### <a name="REDIRECT_URL"></a> REDIRECT_URL
 
 Where to send the user after successful login, if
-[ENABLE_LOGIN](#ENABLE_LOGIN) is `True`
+[ENABLED](#ENABLED) is `True`
 
 <a href="#top">Back to Top</a>
 
 
-#### <a name="LOGIN_URL"></a> LOGIN_URL
+#### <a name="URI"></a> URI
 
 This is the URI portion of an entire URL that our library will attach an
 interceptor to for GET and POST requests.

--- a/oauth2.md
+++ b/oauth2.md
@@ -1,0 +1,66 @@
+<a name="#top">Back to Top</a>
+
+# Oauth2 Features
+
+Stormpath provides two Oauth2 workflows:
+
+### Client Credentials
+
+In this workflow, an api key and secret is provisioned for an account.  These
+credentials can be exchanged for an access token by making a POST request
+to `/oauth/token`.  The request must contain the header
+`Authorization: Basic <base64UrlEncoded(apiKeyId:apiKeySecret)` and the body
+must contain `grant_type=client_credentials`
+
+The underlyhing Stormpath SDK is responsible for generating the access token
+and verifying that the API key & secret is valid, and that the account is not
+disabled
+
+The develoepr can specify these options for th client credentials workflow:
+
+```yaml
+web:
+  oauth2:
+    enabled: true
+    uri: "/oauth/token"
+    client_credentials:
+      enabled: true
+      accessToken:
+        ttl: 3600
+```
+
+The `ttl` determines the expiration time of the token.  This is a value in seconds.
+
+### Password
+
+In this workflow, an account can post their username and password to the
+`/oauth/token` endpoint, with the following body data:
+
+```
+grant_type=client_credentials
+username=<username>
+passwqord=<password>
+```
+
+If the login is successful, we respond with an access token and refresh token.
+
+This feature should use the Application's `/oauth/token` endpoint, on the
+Stormpath API, for creating tokens.  For more infomration please see:
+
+http://docs.stormpath.com/guides/token-management/
+
+The following options are available for this feature:
+
+```yaml
+web:
+  oauth2:
+    password:
+      enabled: true
+```
+
+
+This allows the developer to turn off the password grant flow.  The application's
+oauth policy does contain the ttl values for the access token and refresh
+token, but they do not need to be duplicated here because the framework
+integration does not need to deal with these values when creating tokens, it
+simply invokes the REST API And gets back a token if the credentials are valid.

--- a/registration.md
+++ b/registration.md
@@ -7,7 +7,7 @@
 
 * [Options](#Options)
   * [AUTO_LOGIN](#AUTO_LOGIN)
-  * [ENABLE_REGISTRATION](#ENABLE_REGISTRATION)
+  * [ENABLED](#ENABLED)
   * [REDIRECT_URL](#REDIRECT_URL)
   * [REGISTRATION_URL](#REGISTRATION_URL)
 * [POST Body Format](#POST_Body_Format)
@@ -19,7 +19,7 @@
 This document describes the endpoints and logic that must exist in order to
 facilitate self-service registration of user accounts.
 
-If enabled via the ENABLE_REGISTRATION option, our library MUST intercept
+If enabled via the ENABLED option, our library MUST intercept
 incoming requests for the REGISTRATION_URL and either render a registration
 form (GET) or handle a POST request from the registration form.
 
@@ -58,7 +58,7 @@ framework language (e.g. to camel case, or not)? Is not specified here.
 | ENABLE_GIVEN_NAME                | False         |
 | ENABLE_MIDDLE_NAME               | False         |
 | ENABLE_PASSWORD_CONFIRMATION     | False         |
-| ENABLE_REGISTRATION              | False         |
+| ENABLED              | False         |
 | ENABLE_SURNAME                   | False         |
 | ENABLE_USERNAME                  | False         |
 | REDIRECT_URL                     | /             |
@@ -98,7 +98,7 @@ If enabled, expose a field on the form for entering the user's middle name.
 
 
 
-#### <a name="ENABLE_REGISTRATION"></a> ENABLE_REGISTRATION
+#### <a name="ENABLED"></a> ENABLED
 
 If `True` this feature will be enabled and our library will intercept requests
 at the [REGISTRATION_URL](#REGISTRATION_URL)

--- a/web-config.yaml
+++ b/web-config.yaml
@@ -1,0 +1,108 @@
+---
+web:
+  oauth2:
+    enabled: true
+    uri: "/oauth/token"
+    client_credentials:
+      enabled: true
+      accessToken:
+        ttl: 3600
+  accessTokenCookie:
+    name: "access_token"
+    httpOnly: true
+    secure: null
+    path: "/"
+    domain: null
+  refreshTokenCookie:
+    name: "refresh_token"
+    httpOnly: true
+    secure: null
+    path: "/"
+    domain: null
+  register:
+    enabled: true
+    uri: "/register"
+    nextUri: "/"
+    autoLogin: false
+    fields:
+      username:
+        name: "username"
+        placeholder: "Username"
+        required: false
+        type: "text"
+      givenName:
+        name: "givenName"
+        placeholder: "First Name"
+        required: true
+        type: "text"
+      middleName:
+        name: "middleName"
+        placeholder: "Middle Name"
+        required: false
+        type: "text"
+      surname:
+        name: "surname"
+        placeholder: "Last Name"
+        required: true
+        type: "text"
+      email:
+        name: "email"
+        placeholder: "Email"
+        required: true
+        type: "email"
+      password:
+        name: "password"
+        placeholder: "Password"
+        required: true
+        type: "password"
+      passwordConfirm:
+        name: "passwordConfirm"
+        placeholder: "Confirm Password"
+        required: false
+        type: "password"
+    fieldOrder:
+      - "username"
+      - "givenName"
+      - "middleName"
+      - "surname"
+      - "email"
+      - "password"
+      - "passwordConfirm"
+    view: "register"
+  verifyEmail:
+    enabled: false
+    uri: "/verify"
+    nextUri: "/"
+    view: "verify"
+  login:
+    enabled: true
+    autoLogin: true
+    uri: "/login"
+    nextUri: "/"
+    view: "login"
+  logout:
+    enabled: true
+    uri: "/logout"
+    nextUri: "/"
+  forgotPassword:
+    enabled: false
+    uri: "/forgot"
+    view: "forgot-password"
+    nextUri: "/login?status=forgot"
+  changePassword:
+    enabled: false
+    autoLogin: false
+    uri: "/change"
+    nextUri: "/login?status=reset"
+    view: "change-password"
+    errorUri: "/forgot?status=invalid_sptoken"
+  idSite:
+    enabled: false
+    uri: "/idSiteResult"
+    nextUri: "/"
+    loginUri: ""
+    forgotUri: "/#/forgot"
+    registerUri: "/#/register"
+  me:
+    enabled: false
+    uri: "/me"

--- a/web-config.yaml
+++ b/web-config.yaml
@@ -7,6 +7,8 @@ web:
       enabled: true
       accessToken:
         ttl: 3600
+    password:
+      enabled: true
   accessTokenCookie:
     name: "access_token"
     httpOnly: true


### PR DESCRIPTION
Per discussion from last week, this PR changes the spec to enable the common features by default.

It also contains the YAML representation of the config, and a new document which describes the Oauth2 features.
