### PR TITLE
Expansion options

### DIFF
--- a/web-config.yaml
+++ b/web-config.yaml
@@ -9,6 +9,11 @@ web:
         ttl: 3600
     password:
       enabled: true
+  expand:
+    apiKeys: false
+    customData: true
+    directory: false
+    groups: false
   accessTokenCookie:
     name: "access_token"
     httpOnly: true


### PR DESCRIPTION
In our Express integration we allow developers to specify "automatic expansions".  This tells the integration to automatically expand those child resources on an Account object when an account object is being fetched (during login, registration, etc), essentially pre-warming the cache and reducing the amount of code that is required when the developer wants to interact with an Account object after the framework has fetched it.

The most-used expansion is customData, hence that one being true by default
