### PR TITLE
Clarifying registration, login, SPA integrations

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -6,16 +6,20 @@ The framework integration has a set of configuration options that are specific
 to web applications, this configuration extends the [base configuration for the
 underlying SDK](https://github.com/stormpath/stormpath-sdk-spec/blob/master/specifications/config.md).
 
-The entire framework configuration reference can be found in the [web-config.yaml](web-config.yaml) file.
+The entire framework configuration reference can be found in the
+[web-config.yaml](web-config.yaml) file.
 
-The configuration options inherently refer to high level features that the framework integration should implement, you will find
-that each high level feature has it's own markdown file in this repository.
+The configuration options inherently refer to high level features that the
+framework integration should implement, you will find that each high level
+feature has it's own markdown file in this repository.
 
 ## Application resolution
 
-Our framework intergations will need to know which Stormpath Application should be used (as all authentication features of Stormpath are tied to Applications).
+Our framework intergations will need to know which Stormpath Application should
+be used (as all authentication features of Stormpath are tied to Applications).
 
-The developer needs to specify the application, by name or href, using one of this configuration properties:
+The developer needs to specify the application, by name or href, using one of
+these configuration properties:
 
 ```yaml
 config:
@@ -24,6 +28,26 @@ config:
     href: null
 ```
 
-If neither of these are sepcified, the integration should attempt to use the tenant's only application (if the tenant only has one application).  **MOMTE**: all tenants have an application called "Stormpath", this application cannot be modified and shoud be excluded when looking to see if the tenant only has one application.
+If neither of these are specified, the integration should attempt to use the
+tenant's only application (if the tenant only has one application).  **NOTE**:
+all tenants have an application called "Stormpath", this application cannot be
+modified and should be excluded when looking to see if the tenant only has one
+application.
 
-If the developer does not specify any application configuration, and more applications exist beyind the default 'My Application', then an error should be given to the developer - it should let them know that they need to define an explicit application.
+If the developer does not specify any application configuration, and more
+applications exist beyond the default 'My Application', then an error should be
+given to the developer - it should let them know that they need to define an
+application.
+
+## Account Store Resolution
+
+Account stores are required for login and registration.  As such, we need to
+look at the account stores that are mapped to the application that is specified
+by the developer.
+
+If the specified application does not have any account stores mapped to it,
+this exception should be thrown:
+
+> No account stores are mapped to the specified application.
+  Account stores are required for login and registration.
+

--- a/cookie-authentication.md
+++ b/cookie-authentication.md
@@ -13,7 +13,7 @@ cookies as the secure storage location on the client.
 
 ### Authentication Flow
 
-1. The user visits the login page and submits their username and password.
+1. The user visits the login page and submits their login and password.
 
 2. The integration uses the SDK to perform the password grant exchange, using
     the Stormpath Application's `/oauth/token` endpoint.

--- a/cookie-authentication.md
+++ b/cookie-authentication.md
@@ -13,7 +13,7 @@ cookies as the secure storage location on the client.
 
 ### Authentication Flow
 
-1. The user visits the login page and submits their username and password
+1. The user visits the login page and submits their username and password.
 
 2. The integration uses the SDK to perform the password grant exchange, using
     the Stormpath Application's `/oauth/token` endpoint.
@@ -27,12 +27,15 @@ cookies as the secure storage location on the client.
     logic, using the SDK's relevant JWT and OAuth authenticators:
 
   * If the access token is valid, authenticate the request
+
   * If the access token is invalid, attempt to use the refresh token to get a
-  new access token
+  new access token.
+
   * If a new access token is obtained, authenticate the request and store this
-  new token value in the access token cookie
+  new token value in the access token cookie.
+
   * If a new access token cannot be obtained, reject the request and delete the
-    refresh token cookie
+    refresh token cookie and the access token cookie.
 
 ### Rejecting Requests
 
@@ -83,8 +86,7 @@ token, as defined by the Oauth Policy of the Stormpath Application.
 The developer has control over the name of the cookie and the flags that
 control the cookie behavior in the browser.  The lifetime of the cookies is
 controlled by the application's OAuth Policy, and as such is not represented
-in these option blocks.  But you will need to know what those policy settings
-are, and you will find them at `web.oauth2.password`.
+in these option blocks.
 
 ```yaml
 web:

--- a/email-verification.md
+++ b/email-verification.md
@@ -7,7 +7,7 @@
 This document describes the endpoints and logic that must exist in order to
 facilitate self-service verification of newly registered user accounts.
 
-If an application's default account store has the email verification workflow
+If the application's default account store has the email verification workflow
 enabled, and `stormpath.web.verify.enabled` is not set to `false`, our library
 MUST intercept incoming requests at `stormpath.web.verify.uri` and follow the
 request handling procedure that is defined below.

--- a/email-verification.md
+++ b/email-verification.md
@@ -25,8 +25,8 @@ enabled, our library MUST intercept incoming GET requests for the
 `uri` and either render an account activation view or an
 error view.
 
-GET requests should serve an HTML Page OR Single Page Application, in either
-case the user should be presented with the appropriate view.
+GET requests should serve an HTML Page which shows the user a success
+or error message, see "GET Response Handling" below.
 
 
 ## <a name="Options"></a> Options

--- a/email-verification.md
+++ b/email-verification.md
@@ -2,143 +2,153 @@
 
 # Email Verification
 
-
-## Table of Contents
-
-* [Options](#Options)
-  * [autoLogin](#autoLogin)
-  * [uri](#uri)
-  * [nextUri](#nextUri)
-* [GET Error Handling](#GET_ERROR_HANDLING)
-* [GET Response Handling](#GET_RESPONSE_HANDLING)
-* [POST Error Handling](#POST_ERROR_HANDLING)
-* [POST Response Handling](#POST_RESPONSE_HANDLING)
-
-
 ## Feature Description
 
 This document describes the endpoints and logic that must exist in order to
 facilitate self-service verification of newly registered user accounts.
 
 If an application's default account store has the email verification workflow
-enabled, our library MUST intercept incoming GET requests for the
-`uri` and either render an account activation view or an
-error view.
+enabled, and `stormpath.web.verify.enabled` is not set to `false`, our library
+MUST intercept incoming requests at `stormpath.web.verify.uri` and follow the
+request handling procedure that is defined below.
 
-GET requests should serve an HTML Page which shows the user a success
-or error message, see "GET Response Handling" below.
+## Request Handling
 
+#### GET requests with `Accept: text/html`:
 
-## <a name="Options"></a> Options
+* If there is a `?sptoken` query parameter in the URL:
 
-This JSON blob lists all the options that are required by this feature.
-Detailed descriptions follow.  How the option names are translated into the
-framework language (*e.g. to camel case, or not*)?  Is not specified here.
+ * Attempt to verify the `sptoken`:
 
-```json
-{
-  "verifyEmail": {
-    "enabled": false,
-    "autoLogin": false,
-    "uri": "/verify",
-    "nextUri": "/"
+   * If the token is valid, redirect to `stormpath.web.verify.nextUri` and
+     append `?status=verified`
+
+   * If the token is invalid:
+
+    * If `stormpath.web.spa.enabled` is `false`, render a form that allows them
+      to request a new link by submitting their email address.  The form should
+      show the error:
+
+     > This verification link is no longer valid. Please request a new link from
+       the form below.
+
+    * If `stormpath.web.spa.enabled` is `true`, return the SPA view.
+
+* If there isn't a `?sptoken` query parameter in the URL:
+
+  * If `stormpath.web.spa.enabled` is `false`, render a form that allows them
+    to request a new link by submitting their email address.
+
+  * If `stormpath.web.spa.enabled` is `true`, return the SPA view.
+
+#### GET requests with `Accept: application/json`:
+
+* If there is a `?sptoken` query parameter in the URL:
+
+ * Attempt to verify the `sptoken`:
+
+  * If the token is valid, respond with `200 OK` and an empty body
+
+  * If the token is invalid, respond with `400 Bad Request` and an error
+    response:
+
+    ```javascript
+    {
+      errors: [
+        {
+          message: 'user friendly error'
+        }
+      ]
+    }
+    ```
+
+* If there is't an `?sptoken` query parameter in the URL, respond with this
+  error:
+
+  ```javascript
+  {
+    errors: [
+      {
+        message: 'sptoken not provided'
+      }
+    ]
   }
+  ```
+
+#### POST Requests
+
+This endpoint accepts post requests from the form which allows you to request
+a new link by entering your email address.  The endpoint should accept the
+request as `application/json` and `application/x-www-form-urlencoded`.
+
+The format of the request is (JSON example):
+
+```javascript
+{
+  "email": "foo@bar.com"
 }
 ```
 
+Regardless of whether or not the email address is associated with a user
+account, we should render a success message that says:
 
-### <a name="enabled"></a> enabled
+> If the email address you entered was associated with an account, you will
+  receive an email from us shortly.
 
-If enabled, the framework should handle requests for the `uri`.  This option
-is disabled by default, but the configuration parser should enable it if the
-default account store of the provided application has the email verification
-workflow enabled
+If the request is `Accept: application/json`, the status of the response should
+be `200 OK` with no body.
+
+## <a name="Options"></a> Options
+
+```yaml
+stormpath:
+  web:
+    # Unless verifyEmail.enabled is specifically set to false, the email
+    # verification feature must be automatically enabled if the default account
+    # store for the defined Stormpath application has the email verification
+    # workflow enabled.
+    verifyEmail:
+      enabled: null
+      uri: "/verify"
+      nextUri: "/login"
+      view: "verify"
+```
+
+
+#### enabled
+
+Default: `null`
+
+Unless explicitly set to false, the email verification feature must be
+automatically enabled if the default account store for the defined Stormpath
+application has the email verification workflow enabled.
 
 <a href="#top">Back to Top</a>
 
 
-### <a name="autoLogin"></a> autoLogin
+#### uri
 
-If enabled, will create the `access_token` cookie and redirect the user to the
-`nextUri?status=verified` if they have successfully verified their account.
+Default: `/verify`
 
-<a href="#top">Back to Top</a>
-
-
-### <a name="uri"></a> uri
-
-This is URI is what we'll attach an interceptor to for GET and POST requests.
+The URI that we'll attach an interceptor to for GET and POST requests, if
+`enabled` is `true`.
 
 <a href="#top">Back to Top</a>
 
 
-### <a name="nextUri"></a> nextUri
+#### nextUri
+
+Default: `/login`
 
 Where to send the user after successful verification.
 
 <a href="#top">Back to Top</a>
 
+#### view
 
-## <a name="GET_ERROR_HANDLING"></a> GET Error Handling
+Default: `verify`
 
-This describes how we handle the response for the `uri` controller after the
-user has arrived at our site with an `spToken` URL parameter.
+A string key which identifies the view template that should be used.  The
+default value may look different for your framework.  The point of this value
+is to allow the developer to override our default view with their own.
 
-If the `spToken` query parameter is invalid, we'll render a failure view to the
-user which contains a form that:
-
-- Displays an error message, and
-- Allows a user to enter their email address to resend the verification email to
-  themselves.
-
-If the request is `Accept: application/json`, the response should be a JSON
-object of the format `{ error: String  }` where String is a user-friendly
-message and the status of the response should be 400.
-
-<a href="#top">Back to Top</a>
-
-
-## <a name="GET_RESPONSE_HANDLING"></a> GET Response Handling
-
-This describes how we handle the response for the `uri` controller, after the
-user has arrived at our site with an `spToken` query parameter.
-
-If `spToken` is valid, we'll render the confirmation view to the user and
-consume the `spToken` with our underlying API -- then redirect the
-user to the `nextUri?status=verified` setting with a new user session (if
-`autoLogin` is `true`).  If `autoLogin` is `false`, notify the user that their
-account is verified and provide a link to the login page.
-
-If the request is `Accept: application/json`, the status of the response should
-be an HTTP 200 and there should be no body.
-
-<a href="#top">Back to Top</a>
-
-
-## <a name="POST_ERROR_HANDLING"></a> POST Error Handling
-
-Regardless of whether or not the email address the user entered was successful,
-we should render a success message along the lines of *"If the email address you
-entered was associated with an account, you will receive an email from us
-shortly."*
-
-If the request is `Accept: application/json`, the status of the response should
-be an HTTP 200 and there should be no body.
-
-<a href="#top">Back to Top</a>
-
-
-## <a name="POST_RESPONSE_HANDLING"></a> POST Response Handling
-
-This describes how we handle the POST response for the `uri`
-controller, after the user has submitted form data.
-
-Regardless of whether or not the email address the user entered was successful,
-we should render a success message along the lines of *"If the email address you
-entered was associated with an account, you will receive an email from us
-shortly."*
-
-If the request is `Accept: application/json`, the status of the response should
-be an HTTP 200 and there should be no body.
-
-<a href="#top">Back to Top</a>

--- a/login.md
+++ b/login.md
@@ -2,36 +2,25 @@
 
 # Account Login
 
-
-## Table of Contents
-
-* [Options](#Options)
-* [POST Body Format](#POST_Body_Format)
-* [POST Error Handling](#POST_Error_Handling)
-* [POST Response Handling](#POST_Response_Handling)
-
-
 ## Feature Description
 
 This document describes the endpoints and logic that must exist in order to
 facilitate self-service login of user accounts.
 
 If enabled by `stormpath.web.login.enabled`, our library MUST intercept incoming
-requests for `stormpath.web.login.uri` and either render a login form (GET) or
-handle a POST request from the login form or JSON client.
+requests for `stormpath.web.login.uri`.
 
-GET requests should serve a default HTML page with a registration form, or the
-single-page-application entry file defined by `stormpath.web.spaRoot`.
+GET requests must:
 
-The form MUST:
+* Serve a default HTML page with a login form, if the request is type is
+  `Accept: text/html` (read down for default form description).
 
-* Require an email address / username AND password.
+* Serve a view model, which describes the login form, if the request is type is
+  `Accept: application/json` (read down for view model).
 
-* Render social login buttons, if social provider account stores exist
-  (see [social.md][]).
+POST requests must:
 
-* Render context specific messages, depending on the status query parameter
-  (see ["Status Messages"](#status-messages) section).
+* Handle a POST request from the default HTML login form or from a JSON client.
 
 ## <a name="Options"></a> Options
 
@@ -100,6 +89,65 @@ is to allow the developer to override our default view with their own.
 
 <a href="#top">Back to Top</a>
 
+
+
+## Default HTML Login Form
+
+The form MUST:
+
+* Require an email address / username AND password.
+
+* Render social login buttons, if social provider account stores exist.
+
+* Render context specific messages, depending on the status query parameter
+  (see ["Status Messages"](#status-messages) section).
+
+
+
+## Login View Model
+
+The login view model should be returned to the client if the GET request is
+`Accept: application/json`.  This is for front-end clients that need to
+dynamically know how to render the login form.
+
+The model should have:
+
+* A list of fields, as defined by `stormpath.web.login.fields`, and ordered by
+  `stormpath.web.login.fieldOrder`.  Fields should only be in the list if their
+  `enabled` property is `true`.  As such the enabled property can be omitted
+  from each list element.
+
+* A list of providers, such as social providers, and the required information
+  to render a UI component for that provider.  At the moment we only have social
+  providers, which simply have a button, so all that is needed is the `clientId`
+  from the given directory configuration.  This is needed by the front-end
+  client to provide the popup-based login flows (see [social.md][]).
+
+Example view model definition:
+
+```javascript
+{
+  "fields": [
+    {
+      "name": "username",
+      "placeholder": "Username or Email",
+      "required": true,
+      "type": "text"
+    },
+    {
+      "name": "password",
+      "placeholder": "Password",
+      "required": true,
+      "type": "password"
+    }
+  ],
+  "providers": {
+    "google": {
+      "clientId": "xxxx"
+    }
+  }
+}
+```
 
 
 ## <a name="POST_Body_Format"></a> POST Body Format

--- a/login.md
+++ b/login.md
@@ -31,7 +31,6 @@ stormpath:
   web:
     login:
       enabled: true
-      autoRedirect: true
       uri: "/login"
       nextUri: "/"
       view: "login"
@@ -64,20 +63,6 @@ Default: `/`
 
 Where to send the user after successful login.  This value can be overridden on
 a per-request basis, if the parameter `?next=uri` is provide on the POST.
-
-#### <a name="autoRedirect"></a> autoRedirect
-
-Default: `true`
-
-If enabled, and a user already has a valid session (Oauth2 token cookies),
-instead of re-rendering the login page we will redirect the user to the URL
-specified by `nextUri`.
-
-If disabled, we won't redirect the user anywhere and will simply re-render the
-login page.  However -- in this case we will *also* destroy any existing OAuth2
-token cookies.  This ensures that odd edge cases won't occur wherein a user is
-viewing a login page but can see their account information in some place (like a
-menu bar).
 
 #### <a name="view"></a> view
 

--- a/login.md
+++ b/login.md
@@ -174,7 +174,18 @@ instead of the defined `nextUri`.
 
 **For JSON responses:**
 
-Send a 200 JSON body response, where the body is the account object.
+Send a 200 JSON body response, where the body contains the account object:
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+
+{
+  account: {
+    // the account that was authenticated
+  }
+}
+```
 
 <a href="#top">Back to Top</a>
 

--- a/login.md
+++ b/login.md
@@ -86,7 +86,7 @@ is to allow the developer to override our default view with their own.
 
 The form MUST:
 
-* Require an email address / username AND password.
+* Require a login (email address or username) AND password.
 
 * Render provider login buttons, if provider account stores are mapped to the
   specified Stormpath application.
@@ -131,7 +131,7 @@ Example view model definition:
     "fields": [
       {
         "label": "Username or Email",
-        "name": "username",
+        "name": "login",
         "placeholder": "Username or Email",
         "required": true,
         "type": "text"
@@ -174,11 +174,11 @@ as `application/json`.
 For example, a form-based post would look like this:
 
 ```x-www-form-urlencoded
-username=robert@stormpath.com&
+login=robert@stormpath.com&
 password=mypassword
 ```
 
-* The `username` field value can be either a username or email.
+* The `login` field value can be either a username or email.
 
 * If either field is omitted, an error will be raised and the page will be
 re-rendered.

--- a/login.md
+++ b/login.md
@@ -145,16 +145,24 @@ Example view model definition:
       }
     ],
   },
-  "providers": [
+  "accountStores": [
     {
-      "providerId": "google",
-      "clientId": "xxxx"
+      "href": "https://api.stormpath.com/v1/directories/whatev"
+      "name": "Name of account store"
+      "provider": {
+        "href": "...",
+        "providerId": "saml"
+        //DO NOT EXPOSE ANY OTHER SAML DATA
+      }
     },
     {
-      "providerId": "saml",
-      "accountStore": {
-        "name": "Name of Saml Provider Directory",
-        "href": "href of the directory"
+      "href": "https://api.stormpath.com/v1/directories/whatev2"
+      "name": "Google"
+      "provider": {
+        "href": "href of the directory",
+        "providerId": "google",
+        "clientId": "WHATEVS",
+        //DO NOT EXPOSE ANY SECRET HERE.  NO CLIENT SECRETS!
       }
     }
   ]

--- a/oauth2.md
+++ b/oauth2.md
@@ -100,8 +100,8 @@ The product guide for this feature can be found here:
 
 http://docs.stormpath.com/guides/token-management/
 
-In this workflow, an account can post their username and password to the
-`/oauth/token` endpoint, with the following body data:
+In this workflow, an account can post their login (username or email) and
+password to the `/oauth/token` endpoint, with the following body data:
 
 ````
 POST /oauth/token
@@ -110,6 +110,9 @@ grant_type=password
 &username=<username>
 &password=<password>
 ````
+
+Although the Oauth2 spec requires the parameter to be named `username`, this
+value can also be the email address of a Stormpath account.
 
 The framework should use the underlying SDK to exchange these credentials
 for an access token response, using the `/oauth/token` endpoint of the

--- a/oauth2.md
+++ b/oauth2.md
@@ -8,7 +8,7 @@ application.
 
 
 
-### OAuth2 Configuration Options
+## OAuth2 Configuration Options
 
 The OAuth2 endpoint can be configured, or disabled entirely:
 

--- a/password-reset.md
+++ b/password-reset.md
@@ -32,7 +32,7 @@ facilitate self-service password reset of existing user accounts.
 If an application's default account store has the password reset workflow
 enabled, our library MUST intercept incoming GET requests for the
 `uri` values presented in this document, and render the appropriate views as
-either an HTML page or Single Page Application.
+an HTML page.
 
 
 ## <a name="options"></a> Options
@@ -169,8 +169,8 @@ will complete the Password Reset workflow.
 This describes how we handle the response for GET requests to the `uri` option
 for the Forgot Password workflow.
 
-The response should be an HTML page or SPA that provides a form with an email
-address field, allowing the user to give the email address of the account that
+The response should be an HTML page that provides a form with an email address
+field, allowing the user to give the email address of the account that
 they want to trigger a password reset email for.
 
 The view must have a conditional block for showing an error message, if the user

--- a/registration.md
+++ b/registration.md
@@ -11,17 +11,24 @@ facilitate self-service registration of user accounts.
 If enabled by `stormpath.web.register.enabled`, our library MUST intercept
 incoming requests for `stormpath.web.register.uri`.
 
-GET requests must:
+GET requests must respond in one of the following ways:
 
 * Serve a default HTML page with a registration form, if the request is type is
-  `Accept: text/html` (read down for default form description).
+  `Accept: text/html` and `text/html` is defined in `stormpath.web.produces`.
+
+* Serve the developer's Single Page Application, if `stormpath.web.spa.enabled`
+  is `true` and `text/html` is defined in `stormpath.web.produces`.
+
+* Serve the registration view model if the request is type is
+  `Accept: application/json` and `application/json` is defined in
+  `stormpath.web.produces`.
 
 POST requests must:
 
 * Handle a POST request from the default HTML registration form or from a JSON
   client.
 
-### Default Registration Form Description
+## Default Registration Form
 
 The default registration form MUST:
 
@@ -61,57 +68,65 @@ stormpath:
       # autoLogin is possible only if the email verification feature is disabled
       # on the default default account store of the defined Stormpath
       # application.
-      fields:
-        givenName:
-          enabled: true
-          name: "givenName"
-          placeholder: "First Name"
-          required: true
-          type: "text"
-        middleName:
-          enabled: false
-          name: "middleName"
-          placeholder: "Middle Name"
-          required: true
-          type: "text"
-        surname:
-          enabled: true
-          name: "surname"
-          placeholder: "Last Name"
-          required: true
-          type: "text"
-        username:
-          enabled: false
-          name: "username"
-          placeholder: "Username"
-          required: true
-          type: "text"
-        email:
-          enabled: true
-          name: "email"
-          placeholder: "Email"
-          required: true
-          type: "email"
-        password:
-          enabled: true
-          name: "password"
-          placeholder: "Password"
-          required: true
-          type: "password"
-        confirmPassword:
-          enabled: false
-          name: "confirmPassword"
-          placeholder: "Conrim Password"
-          required: true
-          type: "password"
-      fieldOrder:
-        - "username"
-        - "givenName"
-        - "middleName"
-        - "surname"
-        - "email"
-        - "password"
-        - "confirmPassword"
+      form:
+        fields:
+          givenName:
+            enabled: true
+            label: "First Name"
+            name: "givenName"
+            placeholder: "First Name"
+            required: true
+            type: "text"
+          middleName:
+            enabled: false
+            label: "Middle Name"
+            name: "middleName"
+            placeholder: "Middle Name"
+            required: true
+            type: "text"
+          surname:
+            enabled: true
+            label: "Last Name"
+            name: "surname"
+            placeholder: "Last Name"
+            required: true
+            type: "text"
+          username:
+            enabled: false
+            label: "Username"
+            name: "username"
+            placeholder: "Username"
+            required: true
+            type: "text"
+          email:
+            enabled: true
+            label: "Email"
+            name: "email"
+            placeholder: "Email"
+            required: true
+            type: "email"
+          password:
+            enabled: true
+            label: "Password"
+            name: "password"
+            placeholder: "Password"
+            required: true
+            type: "password"
+          confirmPassword:
+            enabled: false
+            label: "Conrim Password"
+            name: "confirmPassword"
+            placeholder: "Conrim Password"
+            required: true
+            type: "password"
+        fieldOrder:
+          - "username"
+          - "givenName"
+          - "middleName"
+          - "surname"
+          - "email"
+          - "password"
+          - "confirmPassword"
       view: "register"
 ```
 
@@ -151,25 +166,26 @@ disabled.
 is enabled, how should this error be surfaced?
 
 
-#### <a name="fields"></a> fields
+#### <a name="fields"></a> form.fields
 
-A map of field definitions.  Each field definition has the following properties:
+A map of field definitions.  Each field definition must have the following
+properties:
 
 * `enabled` - Determines if this field should be shown in the registration form.
 
+* `label` - The value that is shown as a descriptive label for the field.
+
+* `name` - The value to apply to the `name` attribute of the HTML input element.
+
+* `placeholder` - The placeholder attribute value for the HTML input element.
+
 * `required` - Determines if this field should be required by the user.
 
-* `name` - The name to apply to the HTML input element.
-
-* `placeholder` - The placeholder value for the HTML input element.
-
-* `type` - the type of HTML input element (e.g. text, password).
-
-If the developer provides any properties that are not defined in the above list,
-the properties should be applied as HTML attributes to the input element.
+* `type` - the value to apply to the `type` attribute of HTML input element
+  (e.g. text, password).
 
 
-#### <a name="fieldOrder"></a> fieldOrder
+#### <a name="fieldOrder"></a> form.fieldOrder
 
 A configurable array that allows the developer to change the order in which the
 fields are rendered.
@@ -177,7 +193,7 @@ fields are rendered.
 
 #### <a name="view"></a> view
 
-Default: 'register'
+Default: `register`
 
 A string key which identifies the view template that should be used.  The
 default value may look different for your framework.  The point of this value
@@ -187,63 +203,84 @@ is to allow the developer to override our default view with their own.
 
 
 
-### Registration View Model
+## Registration View Model
 
 The registration view model should be returned to the client if the GET request
-is `Accept: application/json`.  This is for front-end clients that need to
-dynamically know how to render the registration form.
+is `Accept: application/json` and `stormpath.web.produces` contains
+`application/json`.  This is for front-end clients that need to dynamically know
+how to render the registration form.
 
 The model should have:
 
-* A list of fields, as defined by `stormpath.web.register.fields`, and ordered
-  by `stormpath.web.register.fieldOrder`.  Fields should only be in the list if
-  their `enabled` property is `true`.  As such the enabled property can be
-  omitted from each list element.
+* A list of fields, as defined by `stormpath.web.register.form.fields`, and
+  ordered by `stormpath.web.register.form.fieldOrder`.  Fields should only be in
+  the list if their `enabled` property is `true`.  As such the enabled property
+  can be omitted from each list element.
 
-* A list of providers, such as social providers, and the required information
-  to render a UI component for that provider.  At the moment we only have social
-  providers, which simply have a button, so all that is needed is the `clientId`
-  from the given directory configuration.  This is needed by the front-end
-  client to provide the popup-based authentication flows (see [social][]).
+* A list of providers, such as social providers or SAML providers.  Providers
+  are found by looking at the account store mappings of the specified
+  application.
+  * Social providers will need to expose the `clientId`, as front-end
+    applications will need this.
+  * SAML providers need to provide the name of the directory, so that we know
+    what text to use for the button, and the href, so that we can place this
+    value into the SAML request (as a query parameter in the link that the
+    button points to).
+  * The ordering of this list should follow the ordering of the account store
+    mappings.  **NOTE**: this may change in the future.
 
 Example view model definition:
 
 ```javascript
 {
-  "fields": [
+  "form": {
+    "fields": [
+      {
+        "label": "First Name",
+        "name": "givenName",
+        "placeholder": "First Name",
+        "required": true,
+        "type": "text"
+      },
+      {
+        "label": "Last Name",
+        "name": "surname",
+        "placeholder": "Last Name",
+        "required": true,
+        "type": "text"
+      },
+      {
+        "label": "Email",
+        "name": "email",
+        "placeholder": "Email",
+        "required": true,
+        "type": "email"
+      },
+      {
+        "label": "Password",
+        "name": "password",
+        "placeholder": "Password",
+        "required": true,
+        "type": "password"
+      },
+      {
+        // .. other fields, as configured
+      }
+    ],
+  },
+  "providers": [
     {
-      "name": "givenName",
-      "placeholder": "First Name",
-      "required": true,
-      "type": "text"
-    },
-    {
-      "name": "surname",
-      "placeholder": "Last Name",
-      "required": true,
-      "type": "text"
-    },
-    {
-      "name": "email",
-      "placeholder": "Email",
-      "required": true,
-      "type": "email"
-    },
-    {
-      "name": "password",
-      "placeholder": "Password",
-      "required": true,
-      "type": "password"
-    },
-    {
-      // .. other fields, as configured
-    }
-  ],
-  "providers": {
-    "google": {
+      "providerId": "google",
       "clientId": "xxxx"
+    },
+    {
+      "providerId": "saml",
+      "accountStore": {
+        "name": "Name of Saml Provider Directory",
+        "href": "href of the directory"
+      }
     }
-  }
+  ]
 }
 ```
 
@@ -260,7 +297,7 @@ This section uses JSON for example purposes.
 
 Every POST body MUST contain, at a minimum, these fields:
 
-```json
+```javascript
 {
     "email": "robert@stormpath.com",
     "password": "changeme"
@@ -278,10 +315,10 @@ user in the POST, and the developer has configured these fields to be optional
 library MUST set the value to 'UNKNOWN' when we create the account via the
 Stormpath REST API (as the API requires these fields to be populated).
 
-### Configurable Fields
+### Custom Fields
 
 The developer should be able to define their own fields in the
-`stormpath.web.register` configuration block.  If the configured field has
+`stormpath.web.register.form.fields` block.  If the configured field has
 `required: true`, the form parser should error if the user does not submit
 the value.
 
@@ -295,7 +332,7 @@ to be posted to an account's custom data object.
 
 A post with custom fields may look like this:
 
-```json
+```javascript
 {
     "email": "robert@stormpath.com",
     "password": "d",
@@ -316,10 +353,18 @@ For any errors indicated in this document, the following should happen:
 HTML form should be re-rendered with a UX that indicates which field is in error
 and what can be done to fix the problem.
 
-* If the request is `Accept: application/json`, the response should be a JSON
-object of the format `{ error: String }`, where String is a user-friendly message
-and the status of the response should be 400.  If the error is from the
-Stormpath REST API, then send the `userMessage` property of that error.
+* If the request is `Accept: application/json`, the response should be HTTP 400
+and a JSON object of the format:
+
+```javascript
+{
+  "errors": [
+    {
+      "message": "User-friendly error message"
+    }
+  ]
+}
+```
 
 ## <a name="POST_Response_Handling"></a> POST Response Handling
 

--- a/registration.md
+++ b/registration.md
@@ -1,3 +1,4 @@
+
 <a name="#top">Back to Top</a>
 
 # Account Registration
@@ -15,124 +16,174 @@
 This document describes the endpoints and logic that must exist in order to
 facilitate self-service registration of user accounts.
 
-If enabled via the ENABLED option, our library MUST intercept
-incoming requests for the `uri` and either render a registration
-form (GET) or handle a POST request from the registration form.
+If enabled by `stormpath.web.register.enabled`, our library MUST intercept
+incoming requests for the `uri` and either render a registration form (GET) or
+handle a POST request for a registration attempt.
 
-GET requests should serve an HTML Page OR Single Page Application, in either
-case the user should be presented with a registration form.
+GET requests should serve a default HTML page with a registration form, or the
+single-page-application entry file defined by `stormpath.web.spaRoot`.
 
-The form MUST:
+### Default Registration Form Description
 
-* Require a first name
-* Require a last name
-* Require an email address
-* Require a password
+The default registration form MUST:
 
-The form MAY:
+* Require a first name (givenName).
+* Require a last name (surname).
+* Require an email address.
+* Require a password.
 
-* Have other fields:
- * Username
- * Middle Name
- * Password confirmation field
+The form MAY be configured by the developer, allowing them to:
 
-If the following account properties are not specified by the user in the form
-POST, our library MUST set the value to 'UNKNOWN' when we create the account:
-
- * Given Name
- * Surname
+* Make the `givenName` and `surname` fields optional (`required: false`).
+* Remove the `givenName` and `surname` fields (`enabled: false`).
+* Enable other default Stormpath Account fields (`username`, `middleName`).
+* Enable the a password confirmation field.
+* Define custom fields.
 
 ## <a name="Options"></a> Options
 
 This is the set of default configuration for the registration feature, it
 defines the default fields we support and which ones we want to show by
-default.  If a field is `enabled`, it shoud be shown on the registration form.
-If it is `required`, the form must show an erorr if the value is not supplied.
+default.  If a field is `enabled`, it should be shown on the registration form.
+If it's `required` then an error should be returned if the value is not
+supplied by the user.
+
+The developer can define custom fields by creating new field definitions in the
+`fields` map.  New fields MUST have all the properties that you see on our
+default fields.
 
 ```yaml
 stormpath:
   web:
-  register:
-    enabled: false
-    uri: "/register"
-    nextUri: "/"
-    autoLogin: false
-    fields:
-      givenName:
-        enabled: true
-        name: "givenName"
-        placeholder: "First Name"
-        required: true
-        type: "text"
-      middleName:
-        enabled: false
-        name: "middleName"
-        placeholder: "Middle Name"
-        required: true
-        type: "text"
-      surname:
-        enabled: true
-        name: "surname"
-        placeholder: "Last Name"
-        required: true
-        type: "text"
-      username:
-        enabled: false
-        name: "username"
-        placeholder: "Username"
-        required: true
-        type: "text"
-      email:
-        enabled: true
-        name: "email"
-        placeholder: "Email"
-        required: true
-        type: "email"
-      password:
-        enabled: true
-        name: "password"
-        placeholder: "Password"
-        required: true
-        type: "password"
-      confirmPassword:
-        enabled: false
-        name: "confirmPassword"
-        placeholder: "Conrim Password"
-        required: true
-        type: "password"
-    fieldOrder:
-      - "username"
-      - "givenName"
-      - "middleName"
-      - "surname"
-      - "email"
-      - "password"
-      - "confirmPassword"
-    view: "register"
+    register:
+      enabled: true
+      uri: "/register"
+      nextUri: "/"
+      autoLogin: false
+      # autoLogin is possible only if the email verification feature is disabled
+      # on the default default account store of the defined Stormpath
+      # application.
+      fields:
+        givenName:
+          enabled: true
+          name: "givenName"
+          placeholder: "First Name"
+          required: true
+          type: "text"
+        middleName:
+          enabled: false
+          name: "middleName"
+          placeholder: "Middle Name"
+          required: true
+          type: "text"
+        surname:
+          enabled: true
+          name: "surname"
+          placeholder: "Last Name"
+          required: true
+          type: "text"
+        username:
+          enabled: false
+          name: "username"
+          placeholder: "Username"
+          required: true
+          type: "text"
+        email:
+          enabled: true
+          name: "email"
+          placeholder: "Email"
+          required: true
+          type: "email"
+        password:
+          enabled: true
+          name: "password"
+          placeholder: "Password"
+          required: true
+          type: "password"
+        confirmPassword:
+          enabled: false
+          name: "confirmPassword"
+          placeholder: "Conrim Password"
+          required: true
+          type: "password"
+      fieldOrder:
+        - "username"
+        - "givenName"
+        - "middleName"
+        - "surname"
+        - "email"
+        - "password"
+        - "confirmPassword"
+      view: "register"
 ```
-#### <a name="autoLogin"></a> autoLogin
 
-If enabled, will create the `access_token` cookie and redirect the user to the
-nextUri if they have successfully registered.  See the
-[POST Response Handling](#POST_Response_Handling) section for more details.
-Works in conjunction with our Email Verification feature.
 
-<a href="#top">Back to Top</a>
+#### <a name="enabled"></a> enabled
 
+Default: `true`
+
+This determines if the integration will handle the registration route, defined
+by `stormpath.web.registration.uri`
+
+
+#### <a name="uri"></a> uri
+
+Default: `/register`
+
+This URI that our integration should bind to for handling GET and POST requests
+for the `uri`.
 
 
 #### <a name="nextUri"></a> nextUri
 
-Where to send the user after successful registration, if
-[autoLogin](#autoLogin) is `True`
+Default: `/`
 
-<a href="#top">Back to Top</a>
+Where to send the user after successful registration, if [autoLogin](#autoLogin)
+is `True`.
 
 
-#### <a name="`uri`"></a> `uri`
+#### <a name="autoLogin"></a> autoLogin
 
-This is the URI portion of an entire URL that our library will attach an
-interceptor to for GET and POST requests.
+If enabled, the user should be automatically logged in and redirected to the
+`nextUri` after a successful registration.  This is only possible if the
+default account store for the application has the email verification workflow
+disabled.
+
+**Not yet determined**: if auto login is not possible because email verification
+is enabled, how should this error be surfaced?
+
+
+#### <a name="fields"></a> fields
+
+A map of field definitions.  Each field definition has the following properties:
+
+* `enabled` - Determines if this field should be shown in the registration form.
+
+* `required` - Determines if this field should be required by the user.
+
+* `name` - The name to apply to the HTML input element.
+
+* `placeholder` - The placeholder value for the HTML input element.
+
+* `type` - the type of HTML input element (e.g. text, password).
+
+If the developer provides any properties that are not defined in the above list,
+the properties should be applied as HTML attributes to the input element.
+
+
+#### <a name="fieldOrder"></a> fieldOrder
+
+A configurable array that allows the developer to change the order in which the
+fields are rendered.
+
+
+#### <a name="view"></a> view
+
+Default: 'register'
+
+A string key which identifies the view template that should be used.  The
+default value may look different for your framework.  The point of this value
+is to allow the developer to override our default view with their own.
 
 <a href="#top">Back to Top</a>
 
@@ -143,29 +194,52 @@ interceptor to for GET and POST requests.
 The content type of the POST may be `application/x-www-form-urlencoded` or
 `application/json`, the framework should be configured to accept both.
 
-In this section I will use JSON as the example.
+This section uses JSON for example purposes.
 
+### Required Fields
 
 Every POST body MUST contain, at a minimum, these fields:
 
 ```json
 {
     "email": "robert@stormpath.com",
-    "password": "d"
+    "password": "changeme"
 }
 ```
 
 If those fields are omitted, it is an error.  If any of the required fields are
 omitted, that is also an error.
 
-The POST body may contain custom data, which should be passed along to the
-Stormpath API when creating the account.
+### givenName and surname fields
+
+If the `givenName` and `surname` account properties are not specified by the
+user in the POST, and the developer has configured these fields to be optional
+(`required: false`), or has disabled them entirely (`enabled: false`), our
+library MUST set the value to 'UNKNOWN' when we create the account via the
+Stormpath REST API (as the API requires these fields to be populated).
+
+### Configurable Fields
+
+The developer should be able to define their own fields in the
+`stormpath.web.register` configuration block.  If the configured field has
+`required: true`, the form parser should error if the user does not submit
+the value.
+
+Custom fields can be supplied on the root of the post body, or as child
+properties of the custom data field.  Regardless of how they are supplied, the
+library should apply these properties to the account's custom data object.
+
+If the post contains a custom field that it NOT defined by the developer, the
+library MUST reject the request with an error.  We do not allow arbitrary data
+to be posted to an account's custom data object.
+
+A post with custom fields may look like this:
 
 ```json
 {
     "email": "robert@stormpath.com",
     "password": "d",
-    "customValue": "custom value on object root needs to go in custom data, too",
+    "customValue": "custom value can be on root object or in customData object",
     "customData": {
       "hello": "world"
     }
@@ -179,33 +253,35 @@ Stormpath API when creating the account.
 For any errors indicated in this document, the following should happen:
 
 * If the request is `Accept: text/html`, the response should be 200 OK and the
-form should be re-rendered with a UX that indicates which field is in error and
-what can be done to fix the problem.
+HTML form should be re-rendered with a UX that indicates which field is in error
+and what can be done to fix the problem.
 
 * If the request is `Accept: application/json`, the response should be a JSON
-object of the format `{ error: String }` where String is a user-friendly message
-and the status of the response should be 400.
+object of the format `{ error: String }`, where String is a user-friendly message
+and the status of the response should be 400.  If the error is from the
+Stormpath REST API, then send the `userMessage` property of that error.
 
 ## <a name="POST_Response_Handling"></a> POST Response Handling
 
-This describes how we handle the response, after an account has been
-successfully created.
+This describes how we handle the response, if an account has been successfully
+created.
 
 * If the request is `Accept: application/json`, the response should be status
   200 with a JSON body.  The body should be the account object that was returned
   from the account creation call.
-```
 
 * If the request is `Accept: text/html`, and..
   * The newly created account's status is ENABLED and [autoLogin](#autoLogin)
     is:
-    * `True`: issue a 302 Redirect to the nextUri and create set
-      `access_token` cookie on the client
-    * `False`: inform the user that their account has been created and they may
-      now login
-  * The newly created account status is UNVERIFIED, then render a view which
-  tells the user to check their email for a verification link.  This view should
-  containa  link to the VERIFY view, reading "didn't get the email? click here
-  to re-send the message."
+    * `True`: issue a 302 Redirect to the `nextUri` and log the user in (create
+      the OAuth2 token cookies).
+    * `False`: 302 redirect the user to `stormpath.web.login.uri`, and append
+      the query parameter `?status=created` (see [login page status messages][]).
+
+  * The newly created account status is UNVERIFIED, then 302 redirect the user
+    to `stormpath.web.login.uri` and append the query parameter
+    `?status=unverified` (see [login page status messages][]).
 
 <a href="#top">Back to Top</a>
+
+[login page status messages]: login.md#status-messages

--- a/registration.md
+++ b/registration.md
@@ -3,25 +3,23 @@
 
 # Account Registration
 
-
-## Table of Contents
-
-* [Options](#Options)
-* [POST Body Format](#POST_Body_Format)
-* [POST Error Handling](#POST_Error_Handling)
-* [POST Response Handling](#POST_Response_Handling)
-
 ## Feature Description
 
 This document describes the endpoints and logic that must exist in order to
 facilitate self-service registration of user accounts.
 
 If enabled by `stormpath.web.register.enabled`, our library MUST intercept
-incoming requests for the `uri` and either render a registration form (GET) or
-handle a POST request for a registration attempt.
+incoming requests for `stormpath.web.register.uri`.
 
-GET requests should serve a default HTML page with a registration form, or the
-single-page-application entry file defined by `stormpath.web.spaRoot`.
+GET requests must:
+
+* Serve a default HTML page with a registration form, if the request is type is
+  `Accept: text/html` (read down for default form description).
+
+POST requests must:
+
+* Handle a POST request from the default HTML registration form or from a JSON
+  client.
 
 ### Default Registration Form Description
 
@@ -189,6 +187,68 @@ is to allow the developer to override our default view with their own.
 
 
 
+### Registration View Model
+
+The registration view model should be returned to the client if the GET request
+is `Accept: application/json`.  This is for front-end clients that need to
+dynamically know how to render the registration form.
+
+The model should have:
+
+* A list of fields, as defined by `stormpath.web.register.fields`, and ordered
+  by `stormpath.web.register.fieldOrder`.  Fields should only be in the list if
+  their `enabled` property is `true`.  As such the enabled property can be
+  omitted from each list element.
+
+* A list of providers, such as social providers, and the required information
+  to render a UI component for that provider.  At the moment we only have social
+  providers, which simply have a button, so all that is needed is the `clientId`
+  from the given directory configuration.  This is needed by the front-end
+  client to provide the popup-based authentication flows (see [social][]).
+
+Example view model definition:
+
+```javascript
+{
+  "fields": [
+    {
+      "name": "givenName",
+      "placeholder": "First Name",
+      "required": true,
+      "type": "text"
+    },
+    {
+      "name": "surname",
+      "placeholder": "Last Name",
+      "required": true,
+      "type": "text"
+    },
+    {
+      "name": "email",
+      "placeholder": "Email",
+      "required": true,
+      "type": "email"
+    },
+    {
+      "name": "password",
+      "placeholder": "Password",
+      "required": true,
+      "type": "password"
+    },
+    {
+      // .. other fields, as configured
+    }
+  ],
+  "providers": {
+    "google": {
+      "clientId": "xxxx"
+    }
+  }
+}
+```
+
+
+
 ## <a name="POST_Body_Format"></a> POST Body Format
 
 The content type of the POST may be `application/x-www-form-urlencoded` or
@@ -295,3 +355,4 @@ Content-Type: application/json; charset=utf-8
 <a href="#top">Back to Top</a>
 
 [login page status messages]: login.md#status-messages
+[social]: social.md

--- a/registration.md
+++ b/registration.md
@@ -267,8 +267,18 @@ This describes how we handle the response, if an account has been successfully
 created.
 
 * If the request is `Accept: application/json`, the response should be status
-  200 with a JSON body.  The body should be the account object that was returned
-  from the account creation call.
+  200 with a JSON body, where the body contains the account object:
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+
+{
+  account: {
+    // the account that was created
+  }
+}
+```
 
 * If the request is `Accept: text/html`, and..
   * The newly created account's status is ENABLED and [autoLogin](#autoLogin)

--- a/registration.md
+++ b/registration.md
@@ -73,49 +73,42 @@ stormpath:
           givenName:
             enabled: true
             label: "First Name"
-            name: "givenName"
             placeholder: "First Name"
             required: true
             type: "text"
           middleName:
             enabled: false
             label: "Middle Name"
-            name: "middleName"
             placeholder: "Middle Name"
             required: true
             type: "text"
           surname:
             enabled: true
             label: "Last Name"
-            name: "surname"
             placeholder: "Last Name"
             required: true
             type: "text"
           username:
             enabled: false
             label: "Username"
-            name: "username"
             placeholder: "Username"
             required: true
             type: "text"
           email:
             enabled: true
             label: "Email"
-            name: "email"
             placeholder: "Email"
             required: true
             type: "email"
           password:
             enabled: true
             label: "Password"
-            name: "password"
             placeholder: "Password"
             required: true
             type: "password"
           confirmPassword:
             enabled: false
             label: "Conrim Password"
-            name: "confirmPassword"
             placeholder: "Conrim Password"
             required: true
             type: "password"
@@ -168,14 +161,13 @@ is enabled, how should this error be surfaced?
 
 #### <a name="fields"></a> form.fields
 
-A map of field definitions.  Each field definition must have the following
-properties:
+A map of field definitions.  The name of the property, e.g. `givenName`, should
+be applied to the HTML input element as the `name` attribute.  Each field
+definition must have the following properties:
 
 * `enabled` - Determines if this field should be shown in the registration form.
 
 * `label` - The value that is shown as a descriptive label for the field.
-
-* `name` - The value to apply to the `name` attribute of the HTML input element.
 
 * `placeholder` - The placeholder attribute value for the HTML input element.
 

--- a/registration.md
+++ b/registration.md
@@ -260,16 +260,24 @@ Example view model definition:
       }
     ],
   },
-  "providers": [
+  "accountStores": [
     {
-      "providerId": "google",
-      "clientId": "xxxx"
+      "href": "https://api.stormpath.com/v1/directories/whatev"
+      "name": "Name of account store"
+      "provider": {
+        "href": "...",
+        "providerId": "saml"
+        //DO NOT EXPOSE ANY OTHER SAML DATA
+      }
     },
     {
-      "providerId": "saml",
-      "accountStore": {
-        "name": "Name of Saml Provider Directory",
-        "href": "href of the directory"
+      "href": "https://api.stormpath.com/v1/directories/whatev2"
+      "name": "Google"
+      "provider": {
+        "href": "href of the directory",
+        "providerId": "google",
+        "clientId": "WHATEVS",
+        //DO NOT EXPOSE ANY SECRET HERE.  NO CLIENT SECRETS!
       }
     }
   ]

--- a/single-page-apps.md
+++ b/single-page-apps.md
@@ -1,0 +1,135 @@
+# Single Page Applications
+
+Our integration needs to play nice with Single Page Applications (SPAs), such
+as Angular.js and React.
+
+Typical SPAs have an "entry", which is an HTML file (usually index.html) that
+loads serveral javascript files and css files.  Once loaded, the application
+will bootstrap.
+
+## Background: Routing
+
+"Routing" for SPAs refers to the strategy by which URLs map onto specific views
+or states in the SPA.
+
+For example, you may have URLs like this:
+
+```
+http://myapp.com
+http://myapp.com/blog
+http://myapp.com/blog/:postId
+```
+
+Or like this:
+
+```
+http://myapp.com
+http://myapp.com/#blog
+http://myapp.com/#blog/:postId
+```
+
+The latter is referred to as "hash bang" routing.  This is a simpler situation
+and does not require coordination from the server.
+
+The former is referred to as "HTML5" routing, as it leverages an HTML5 API in
+the browser.  This API allows the user to navigate to absolute URLS, but the
+browser will not make GET requests of the server for each URL.  The browser
+merely updates the URL in the URL bar, and expects that the SPA will observe
+this and render the appropriate view.  The SPA will likely make a JSON GET
+request of the server, to load the data that is required to populate the view.
+
+However, if the user hits the reload button (or visits the URL directly, from
+another site) a GET request *will* be made of the server.  It is this situation
+that becomes interesting.
+
+In this situation, the server needs to render the entry for the SPA - so that
+the SPA can bootstrap and then render the appropriate view.
+
+This impacts our integration because we need to know how we should respond
+when a `Accept: text/html` GET request comes in for `/login` and other URLs that
+we bind to. Do we serve our default HTML pages, or do we serve the SPA entry?
+Or do we ignore HTML entirely, and leave the SPA configuration up to the
+developer?
+
+## Configuration
+
+We have the following default configuration options to support these various
+routing and SPA use-cases:
+
+```yaml
+stormpath:
+  web:
+    produces:
+      - text/html
+      - application/json
+    spa:
+      enabled: false
+      view: index
+```
+
+These can be combined to achieve the following use-cases:
+
+**I don't want Stormpath to handle my SPA assets / I want just JSON**
+
+In this situation, the developer likely wants "just the JSON api" to be
+attached to their web application.  In this situation, the developer will
+disable HTML responses of our library.  When this is true, we only respond to
+requests where `Accept: application/json` is present.  The developer must use
+this configuration:
+
+```yaml
+stormpath:
+  web:
+    produces:
+      - application/json
+```
+
+**I want to use the default Stormpath routes with my SPA**
+
+In this situation, the developer wants to use the default routes of `/login`,
+etc, but they want their SPA to be served for these routes.
+
+In this situation, they will need to enable the SPA option:
+
+```yaml
+stormpath:
+  web:
+    spa:
+      enabled: true
+      view: index  # or other value that indicates where the entry is
+```
+
+With this configuration, our integration should always render the SPA entry when
+it wants to render an HTML response, which would otherwise be one of our
+default HTML pages.
+
+## View Models
+
+The login an registration views are dynamic.  The registration form has
+configurable fields, and both login and registration need to dynamically render
+buttons for any providers (Google, Facebook, SAML) that are mapped to the
+specified Stormpath application.
+
+For that reason, we support JSON GET requests of the `/login` and `/register`
+views.  The response is a view model that the client can use to render the
+form appropriately.
+
+Please see [login][] and [registration][] for specific information on each
+model.
+
+
+## React Flux
+
+React Flux is a different approach which does not follow the separation of
+concerns that we've been describing.  In this environment, the server is
+rendering HTML responses which contain the initial view (already populated
+with data) but also providing an API for getting more HTML views or JSON for
+doing more view rendering client-side.
+
+In this situation, the developer should disable HTML responses.  They won't
+provide a SPA entry.  They are likely adding our module to an existing server,
+purely for the JSON API that facilitates our user workflows.
+
+
+[login]: login.md
+[registration]: registration.md

--- a/social.md
+++ b/social.md
@@ -66,7 +66,7 @@ provider, the following must be done:
 
 * Render a login button on the login page (see [Login][]).
 
-* Create a callback handler for the provider's page-pased redirect flow (see
+* Create a callback handler for the provider's page-based redirect flow (see
   next section)
 
 

--- a/social.md
+++ b/social.md
@@ -51,11 +51,11 @@ following:
   * Parse the provider configuration of the specified Stormpath application (see
     next section).
 
-  * Provide the "SPA Config" getter for rich front-end clients, please see "SPA
-    Config" section of this document
-
   * Accept the access token or code via the login endpoint that this framework
-    providers, see [login][] for implementation spec.
+    provides, see [login][] for implementation spec.
+
+  * Render buttons for social login, on the registration and login views (or
+    view model), see [login][] and [registration][].
 
 
 ## Parsing Provider Configuration
@@ -64,7 +64,7 @@ During framework bootstrap, the specified Stormpath application should be parsed
 for it's account store mappings.  If any of these account stores are a social
 provider, the following must be done:
 
-* Render a login button on the login page (see [Login][]).
+* Render a login button on the login page (see [login][]).
 
 * Create a callback handler for the provider's page-based redirect flow (see
   next section)
@@ -94,27 +94,16 @@ callback handler must complete the following tasks:
 If any of these tasks fail, an error should be immediately rendered to the user
 and the next task should not be attempted.
 
-## <a name="SPA_Config"></a> SPA Config
+## Implementing Popup-Based Workflows
 
-If the developer has defined `stormpath.web.spaRoot`, and has not explicitly
-set `stormpath.web.spaConfig.enabled` to `false`, then we should render the
-"SPA Config" response at `stormpath.web.spaConfig.uri`
-
-This GET response handler will render an object that is built during framework
-bootstrap by parsing the account stores that are mapped to the configured
-Stormpath application.
-
-An example SPA Config response is below.  In this example there is only one
-account store that is a social account store and it is a Google account store.
-
-```json
-{
-  "google": {
-    "clientId": "xxxx"
-  }
-}
-```
+Single-page applications will need to query the server to determine which social
+providers are configured, and which fields to render for the login or
+registration views.  In either context, the front-end application should make
+a GET request to the login or registration endpoint, to fetch the view model
+as JSON.  The view model will contain the necessary information.  See [login][]
+and [registration][] pages for the view model definitions.
 
 <a href="#top">Back to Top</a>
 
 [login]: login.md
+[registration]: registration.md

--- a/web-config.yaml
+++ b/web-config.yaml
@@ -110,6 +110,22 @@ stormpath:
       uri: "/login"
       nextUri: "/"
       view: "login"
+      fields:
+        username:
+          enabled: true
+          name: "username"
+          placeholder: "Username or Email"
+          required: true
+          type: "text"
+        password:
+          enabled: true
+          name: "password"
+          placeholder: "Password"
+          required: true
+          type: "password"
+      fieldOrder:
+        - "username"
+        - "password"
 
     logout:
       enabled: true
@@ -149,22 +165,8 @@ stormpath:
     socialProviders:
       callbackRoot: "/callbacks"
 
-    # The /me route if for Single Page Applications.  Unless me.enabled is
-    # explicitly set to false, this feature should be automatically enabled if
-    # the stormpath.web.spaRoot option is defined.
+    # The /me route is for front-end applications, it returns a JSON object with
+    # the current user object
     me:
-      enabled: null
+      enabled: true
       uri: "/me"
-
-    # This should be the absolute file path to the entry point for a Single
-    # Page Application
-    spaRoot: null
-
-    # The /spaConfig route if for Single Page Applications.  It informs the
-    # client about social providers that are configured, and what the client ID
-    # is for those providers.  Unless spaConfig.enabled is set to false, this
-    # feature should be automatically enabled if the stormpath.web.spaRoot
-    # option is defined.
-    spaConfig:
-      enabled: null
-      uri: "/spaConfig"

--- a/web-config.yaml
+++ b/web-config.yaml
@@ -118,7 +118,7 @@ stormpath:
     verifyEmail:
       enabled: null
       uri: "/verify"
-      nextUri: "/"
+      nextUri: "/login"
       view: "verify"
 
     login:

--- a/web-config.yaml
+++ b/web-config.yaml
@@ -1,6 +1,8 @@
 stormpath:
   web:
+
     basePath: null
+
     oauth2:
       enabled: true
       uri: "/oauth/token"
@@ -11,27 +13,34 @@ stormpath:
       password:
         enabled: true
         validationStrategy: stormpath
+
     expand:
       apiKeys: false
       customData: true
       directory: false
       groups: false
+
     accessTokenCookie:
       name: "access_token"
       httpOnly: true
       secure: null
       path: null
       domain: null
+
     refreshTokenCookie:
       name: "refresh_token"
       httpOnly: true
       secure: null
       path: null
       domain: null
+
     register:
-      enabled: false
+      enabled: true
       uri: "/register"
       nextUri: "/"
+      # autoLogin is possible only if the email verification feature is disabled
+      # on the default default account store of the defined Stormpath
+      # application.
       autoLogin: false
       fields:
         givenName:
@@ -85,33 +94,50 @@ stormpath:
         - "password"
         - "confirmPassword"
       view: "register"
+
+    # Unless verifyEmail.enabled is specifically set to false, the email
+    # verification feature must be automatically enabled if the default account
+    # store for the defined Stormpath application has the email verification
+    # workflow enabled.
     verifyEmail:
-      enabled: false
+      enabled: null
       uri: "/verify"
       nextUri: "/"
       view: "verify"
+
     login:
       enabled: true
-      autoRedirect: true
       uri: "/login"
       nextUri: "/"
       view: "login"
+
     logout:
       enabled: true
       uri: "/logout"
       nextUri: "/"
+
+    # Unless forgotPassword.enabled is explicitly set to false, this feature
+    # will be automatically enabled if the default account store for the defined
+    # Stormpath application has the password reset workflow enabled.
     forgotPassword:
-      enabled: false
+      enabled: null
       uri: "/forgot"
       view: "forgot-password"
       nextUri: "/login?status=forgot"
+
+    # Unless changePassword.enabled is explicitly set to false, this feature
+    # will be automatically enabled if the default account store for the defined
+    # Stormpath application has the password reset workflow enabled.
     changePassword:
-      enabled: false
+      enabled: null
       autoLogin: false
       uri: "/change"
       nextUri: "/login?status=reset"
       view: "change-password"
       errorUri: "/forgot?status=invalid_sptoken"
+
+    # If idSite.enabled is true, the user should be redirected to ID site for
+    # login, registration, and password reset.
     idSite:
       enabled: false
       uri: "/idSiteResult"
@@ -119,6 +145,26 @@ stormpath:
       loginUri: ""
       forgotUri: "/#/forgot"
       registerUri: "/#/register"
+
+    socialProviders:
+      callbackRoot: "/callbacks"
+
+    # The /me route if for Single Page Applications.  Unless me.enabled is
+    # explicitly set to false, this feature should be automatically enabled if
+    # the stormpath.web.spaRoot option is defined.
     me:
-      enabled: false
+      enabled: null
       uri: "/me"
+
+    # This should be the absolute file path to the entry point for a Single
+    # Page Application
+    spaRoot: null
+
+    # The /spaConfig route if for Single Page Applications.  It informs the
+    # client about social providers that are configured, and what the client ID
+    # is for those providers.  Unless spaConfig.enabled is set to false, this
+    # feature should be automatically enabled if the stormpath.web.spaRoot
+    # option is defined.
+    spaConfig:
+      enabled: null
+      uri: "/spaConfig"

--- a/web-config.yaml
+++ b/web-config.yaml
@@ -121,7 +121,7 @@ stormpath:
       view: "login"
       form:
         fields:
-          username:
+          login:
             enabled: true
             label: "Username or Email"
             placeholder: "Username or Email"
@@ -134,7 +134,7 @@ stormpath:
             required: true
             type: "password"
         fieldOrder:
-          - "username"
+          - "login"
           - "password"
 
     logout:

--- a/web-config.yaml
+++ b/web-config.yaml
@@ -55,49 +55,42 @@ stormpath:
           givenName:
             enabled: true
             label: "First Name"
-            name: "givenName"
             placeholder: "First Name"
             required: true
             type: "text"
           middleName:
             enabled: false
             label: "Middle Name"
-            name: "middleName"
             placeholder: "Middle Name"
             required: true
             type: "text"
           surname:
             enabled: true
             label: "Last Name"
-            name: "surname"
             placeholder: "Last Name"
             required: true
             type: "text"
           username:
             enabled: false
             label: "Username"
-            name: "username"
             placeholder: "Username"
             required: true
             type: "text"
           email:
             enabled: true
             label: "Email"
-            name: "email"
             placeholder: "Email"
             required: true
             type: "email"
           password:
             enabled: true
             label: "Password"
-            name: "password"
             placeholder: "Password"
             required: true
             type: "password"
           confirmPassword:
             enabled: false
             label: "Conrim Password"
-            name: "confirmPassword"
             placeholder: "Conrim Password"
             required: true
             type: "password"
@@ -131,14 +124,12 @@ stormpath:
           username:
             enabled: true
             label: "Username or Email"
-            name: "username"
             placeholder: "Username or Email"
             required: true
             type: "text"
           password:
             enabled: true
             label: "Password"
-            name: "password"
             placeholder: "Password"
             required: true
             type: "password"

--- a/web-config.yaml
+++ b/web-config.yaml
@@ -34,6 +34,14 @@ stormpath:
       path: null
       domain: null
 
+    # By default the Stormpath integration should respond to JSON and HTML
+    # requests.  If either is removed from configuration, the integration should
+    # not try to handle the response for the given content type.
+
+    produces:
+      - text/html
+      - application/json
+
     register:
       enabled: true
       uri: "/register"
@@ -42,57 +50,65 @@ stormpath:
       # on the default default account store of the defined Stormpath
       # application.
       autoLogin: false
-      fields:
-        givenName:
-          enabled: true
-          name: "givenName"
-          placeholder: "First Name"
-          required: true
-          type: "text"
-        middleName:
-          enabled: false
-          name: "middleName"
-          placeholder: "Middle Name"
-          required: true
-          type: "text"
-        surname:
-          enabled: true
-          name: "surname"
-          placeholder: "Last Name"
-          required: true
-          type: "text"
-        username:
-          enabled: false
-          name: "username"
-          placeholder: "Username"
-          required: true
-          type: "text"
-        email:
-          enabled: true
-          name: "email"
-          placeholder: "Email"
-          required: true
-          type: "email"
-        password:
-          enabled: true
-          name: "password"
-          placeholder: "Password"
-          required: true
-          type: "password"
-        confirmPassword:
-          enabled: false
-          name: "confirmPassword"
-          placeholder: "Conrim Password"
-          required: true
-          type: "password"
-      fieldOrder:
-        - "username"
-        - "givenName"
-        - "middleName"
-        - "surname"
-        - "email"
-        - "password"
-        - "confirmPassword"
+      form:
+        fields:
+          givenName:
+            enabled: true
+            label: "First Name"
+            name: "givenName"
+            placeholder: "First Name"
+            required: true
+            type: "text"
+          middleName:
+            enabled: false
+            label: "Middle Name"
+            name: "middleName"
+            placeholder: "Middle Name"
+            required: true
+            type: "text"
+          surname:
+            enabled: true
+            label: "Last Name"
+            name: "surname"
+            placeholder: "Last Name"
+            required: true
+            type: "text"
+          username:
+            enabled: false
+            label: "Username"
+            name: "username"
+            placeholder: "Username"
+            required: true
+            type: "text"
+          email:
+            enabled: true
+            label: "Email"
+            name: "email"
+            placeholder: "Email"
+            required: true
+            type: "email"
+          password:
+            enabled: true
+            label: "Password"
+            name: "password"
+            placeholder: "Password"
+            required: true
+            type: "password"
+          confirmPassword:
+            enabled: false
+            label: "Conrim Password"
+            name: "confirmPassword"
+            placeholder: "Conrim Password"
+            required: true
+            type: "password"
+        fieldOrder:
+          - "username"
+          - "givenName"
+          - "middleName"
+          - "surname"
+          - "email"
+          - "password"
+          - "confirmPassword"
       view: "register"
 
     # Unless verifyEmail.enabled is specifically set to false, the email
@@ -110,22 +126,25 @@ stormpath:
       uri: "/login"
       nextUri: "/"
       view: "login"
-      fields:
-        username:
-          enabled: true
-          name: "username"
-          placeholder: "Username or Email"
-          required: true
-          type: "text"
-        password:
-          enabled: true
-          name: "password"
-          placeholder: "Password"
-          required: true
-          type: "password"
-      fieldOrder:
-        - "username"
-        - "password"
+      form:
+        fields:
+          username:
+            enabled: true
+            label: "Username or Email"
+            name: "username"
+            placeholder: "Username or Email"
+            required: true
+            type: "text"
+          password:
+            enabled: true
+            label: "Password"
+            name: "password"
+            placeholder: "Password"
+            required: true
+            type: "password"
+        fieldOrder:
+          - "username"
+          - "password"
 
     logout:
       enabled: true
@@ -170,3 +189,18 @@ stormpath:
     me:
       enabled: true
       uri: "/me"
+
+    # If the developer wants our integration to serve their Single Page
+    # Application (SPA) in response to HTML requests for our default routes,
+    # such as /login, then they will need to enable this feature and tell us
+    # where the root of their SPA is.  This is likely a file path on the
+    # filesystem.
+    #
+    # If the developer does not want our integration to handle their SPA, they
+    # will need to configure the framework themeslves and remove 'text/html'
+    # from `stormpath.web.produces`, so that we don not serve our default
+    # HTML views.
+    spa:
+      enabled: false
+      view: index
+


### PR DESCRIPTION
This PR clarifies our strategies around registration and social login.  The diff is quite large, so I'd advise reading the affected documents from top to bottom.  Ping @lhazlewood @omgitstom 

Please note: the social config spec is currently written such that we have some default URLs for the social callback URIs, such as `/callbacks/google`

However I'd like to propose that we read these values from directory configuration, as the developer will have to duplicate this information there anyways.  If this value is null on the directory then we render a warning in the console during framework initialization, "provider callback not defined", and we do not register callback URIs for the provider.

Thanks for the review!
