### PR TITLE
Use local validation by default, for JWT validation

### DIFF
--- a/web-config.yaml
+++ b/web-config.yaml
@@ -12,7 +12,7 @@ stormpath:
           ttl: 3600
       password:
         enabled: true
-        validationStrategy: stormpath
+        validationStrategy: "local"
 
     expand:
       apiKeys: false


### PR DESCRIPTION
I was just talking with @lhazlewood and we've decided to enable local validation by default, as it's better for performance and the experience that most developers would want to have.

Note: we want to ensure that developers know how to configure the OAuth Policy for their application.  In a local validation scenario, it is expected that the TTL of your access token is short (minutes) so that you can revoke the refresh token if needed, and have the "session" terminate as soon as the most recent access token expires.  Please include some notes in your framework documentation.
