### PR TITLE
Change `uri` in config to `path`

### DIFF
--- a/cookie-authentication.md
+++ b/cookie-authentication.md
@@ -136,7 +136,7 @@ cookies over a non-https connection is vulnerable to man-in-the-middle attacks.
 
 #### <a name="path"></a> path
 
-This option determines what URI paths will be able to read the cookie.
+This option determines what paths will be able to read the cookie.
 
 <a href="#top">Back to Top</a>
 

--- a/email-verification.md
+++ b/email-verification.md
@@ -9,7 +9,7 @@ facilitate self-service verification of newly registered user accounts.
 
 If the application's default account store has the email verification workflow
 enabled, and `stormpath.web.verify.enabled` is not set to `false`, our library
-MUST intercept incoming requests at `stormpath.web.verify.uri` and follow the
+MUST intercept incoming requests at `stormpath.web.verify.path` and follow the
 request handling procedure that is defined below.
 
 ## Request Handling
@@ -20,7 +20,7 @@ request handling procedure that is defined below.
 
  * Attempt to verify the `sptoken`:
 
-   * If the token is valid, redirect to `stormpath.web.verify.nextUri` and
+   * If the token is valid, redirect to `stormpath.web.verify.nextPath` and
      append `?status=verified`
 
    * If the token is invalid:
@@ -109,8 +109,8 @@ stormpath:
     # workflow enabled.
     verifyEmail:
       enabled: null
-      uri: "/verify"
-      nextUri: "/login"
+      path: "/verify"
+      nextPath: "/login"
       view: "verify"
 ```
 
@@ -126,17 +126,17 @@ application has the email verification workflow enabled.
 <a href="#top">Back to Top</a>
 
 
-#### uri
+#### path
 
 Default: `/verify`
 
-The URI that we'll attach an interceptor to for GET and POST requests, if
+The path that we'll attach an interceptor to for GET and POST requests, if
 `enabled` is `true`.
 
 <a href="#top">Back to Top</a>
 
 
-#### nextUri
+#### nextPath
 
 Default: `/login`
 

--- a/login.md
+++ b/login.md
@@ -8,7 +8,7 @@ This document describes the endpoints and logic that must exist in order to
 facilitate self-service login of user accounts.
 
 If enabled by `stormpath.web.login.enabled`, our library MUST intercept incoming
-requests for `stormpath.web.login.uri`.
+requests for `stormpath.web.login.path`.
 
 GET requests must:
 
@@ -37,8 +37,8 @@ stormpath:
   web:
     login:
       enabled: true
-      uri: "/login"
-      nextUri: "/"
+      path: "/login"
+      nextPath: "/"
       view: "login"
 ```
 
@@ -47,28 +47,28 @@ stormpath:
 Default: `true`
 
 If `true` this feature will be enabled and our library will intercept requests
-at for `uri`.
+at for `path`.
 
 If `false` this feature is disabled and the base framework will be responsible
-for the `uri`, likely resulting in a 404 Not Found error.
+for the `path`, likely resulting in a 404 Not Found error.
 
 **NOTE**: If this feature is enabled, and no Account Stores are mapped to this
 Application -- then throw an error during framework initialization as there are
 no possible ways for a user to authenticate.
 
-#### <a name="uri"></a> uri
+#### <a name="path"></a> path
 
 Default: `/login`
 
-This URI that our integration should bind to for handling GET and POST requests
-for the `uri`.
+This path that our integration should bind to for handling GET and POST requests
+for the `path`.
 
-#### <a name="nextUri"></a> nextUri
+#### <a name="nextPath"></a> nextPath
 
 Default: `/`
 
 Where to send the user after successful login.  This value can be overridden on
-a per-request basis, if the parameter `?next=uri` is provide on the POST.
+a per-request basis, if the parameter `?next=path` is provide on the POST.
 
 #### <a name="view"></a> view
 
@@ -244,9 +244,9 @@ successfully authenticated.
 
 **For HTML responses:**
 
-Issue a 302 redirect to the `nextUri` and create a new user session.  If the
-form post had a query parameter of `?next=url`, then redirect to that location
-instead of the defined `nextUri`.
+Issue a 302 redirect to the `nextPath` and create a new user session.  If the
+form post had a query parameter of `?next=path`, then redirect to that location
+instead of the defined `nextPath`.
 
 **For JSON responses:**
 
@@ -280,7 +280,7 @@ is unverified.  Message to show:
 > Your account verification email has been sent!  Before you can log into your
   account, you need to activate your account by clicking the link we sent to
   your inbox.  Didn't get the email?
-  `<a href="#{stormpath.web.verifyEmail.uri}">Click Here</a>`
+  `<a href="#{stormpath.web.verifyEmail.path}">Click Here</a>`
 
 * `?status=verified` - the user has successfully verified their account and can
   now login.  Message to show:

--- a/oauth2.md
+++ b/oauth2.md
@@ -16,14 +16,14 @@ The OAuth2 endpoint can be configured, or disabled entirely:
 web:
   oauth2:
     enabled: true
-    uri: "/oauth/token"
+    path: "/oauth/token"
 ```
 
 #### web.oauth2.enabled
 
-By default we accept POSTS to this token uri and respond according to the
+By default we accept POSTS to this token path and respond according to the
 grant type.  If the developer sets this value to false we should not attach any
-handler to this uri, allowing the framework to return it's default 404 response.
+handler to this path, allowing the framework to return it's default 404 response.
 
 If enabled and the grant type is not `client_credentials` or `password`, then we
 should return the OAuth-compliant error code:

--- a/password-reset.md
+++ b/password-reset.md
@@ -24,7 +24,7 @@ reset email.
 If the default account store of the stormapth application has the password reset
 workflow enabled, and `stormpath.web.forgotPassword.enabled` is not set to
 `false`, our library MUST intercept incoming requests at
-`stormpath.web.forgotPassword.uri` and follow the request handling procedure
+`stormpath.web.forgotPassword.path` and follow the request handling procedure
 that is defined below.
 
 ### Request Handling
@@ -59,7 +59,7 @@ Regardless of whether or not the email address is associated with a user
 account, we must do the following:
 
 * If the request is `Accept: application/html`, redirect the user to
-  `stormpath.web.forgot.nextUri`
+  `stormpath.web.forgot.nextPath`
 
 * If the request is `Accept: application/json`, respond with `200 OK` and no
   body.
@@ -71,9 +71,9 @@ stormpath:
   web:
     forgotPassword:
       enabled: null
-      uri: "/forgot"
+      path: "/forgot"
       view: "forgot-password"
-      nextUri: "/login?status=forgot"
+      nextPath: "/login?status=forgot"
 ```
 
 #### enabled
@@ -87,21 +87,21 @@ reset workflow enabled.
 <a href="#top">Back to Top</a>
 
 
-#### uri
+#### path
 
 Default: `/forgot`
 
-The URI that we'll attach an interceptor to for requests, if `enabled` is
+The path that we'll attach an interceptor to for requests, if `enabled` is
 `true`.
 
 <a href="#top">Back to Top</a>
 
 
-#### nextUri
+#### nextPath
 
 Default: `/login?status=forgot`
 
-This is the URI we'll redirect the user to after a user has successfully
+This is the path we'll redirect the user to after a user has successfully
 initialized the Password Reset workflow by submitting an email address.
 
 <a href="#top">Back to Top</a>
@@ -132,7 +132,7 @@ this endpoint, and contain the `sptoken` query parameter.
     consume the token yet.
 
   * If the `sptoken` is invalid, redirect the user to
-    `stormpath.web.changePassword.errorUri`.
+    `stormpath.web.changePassword.errorPath`.
 
   * If the `sptoken` is valid:
 
@@ -144,7 +144,7 @@ this endpoint, and contain the `sptoken` query parameter.
 
 * If there isn't a `?sptoken` query parameter in the URL:
 
-  * Redirect the user to `stormpath.web.forgotPassword.uri`
+  * Redirect the user to `stormpath.web.forgotPassword.path`
 
 #### POST Handling
 
@@ -170,10 +170,10 @@ appropriate case:
 * If the request is `Accept: text/html`:
 
   * If `autoLogin` is `false`, redirect the user to
-    `stormpath.web.changePassword.nextUri`
+    `stormpath.web.changePassword.nextPath`
 
   * If `autoLogin` is `true`, log the user in (create the Oauth2 cookies) and
-    redirect the user to `stormpath.web.login.nextUri`
+    redirect the user to `stormpath.web.login.nextPath`
 
 * If the request is `Accept: application/json`:
 
@@ -203,7 +203,7 @@ If an error is encountered, respond with the appropriate case:
     password form and display the error to the user
 
   * If the error is an invalid or expired token error, redirect the user to
-    `stormpath.web.changePassword.errorUri`
+    `stormpath.web.changePassword.errorPath`
 
 * If the request is `Accept: application/json`:
 
@@ -227,9 +227,9 @@ stormpath:
     changePassword:
       enabled: null
       autoLogin: false
-      uri: "/change"
-      errorUri: "/forgot?status=invalid_sptoken"
-      nextUri: "/login?status=reset"
+      path: "/change"
+      errorPath: "/forgot?status=invalid_sptoken"
+      nextPath: "/login?status=reset"
       view: "change-password"
 
 ```
@@ -252,37 +252,37 @@ reset workflow enabled.
 Default: `false`
 
 If `true`, then once a user has successfully reset their password, they will be
-automatically logged in and redirected to `stormpath.web.login.nextUri`.
+automatically logged in and redirected to `stormpath.web.login.nextPath`.
 
 
 <a href="#top">Back to Top</a>
 
 
-#### uri
+#### path
 
 Default: `/change`
 
-The URI that we'll attach an interceptor to for requests, if `enabled` is
+The path that we'll attach an interceptor to for requests, if `enabled` is
 `true`.
 
 <a href="#top">Back to Top</a>
 
 
-#### <a name="change-error-uri"></a> errorUri
+#### <a name="change-error-path"></a> errorPath
 
 Default: `/forgot?status=invalid_sptoken`
 
-This is the URI we'll redirect a user to if they have arrived with an invalid
+This is the path we'll redirect a user to if they have arrived with an invalid
 `sptoken`.
 
 <a href="#top">Back to Top</a>
 
 
-#### nextUri
+#### nextPath
 
 Default: `/login?status=reset`
 
-This is the URI we'll redirect the user to after they have successfully reset
+This is the path we'll redirect the user to after they have successfully reset
 their account password.
 
 <a href="#top">Back to Top</a>

--- a/registration.md
+++ b/registration.md
@@ -9,7 +9,7 @@ This document describes the endpoints and logic that must exist in order to
 facilitate self-service registration of user accounts.
 
 If enabled by `stormpath.web.register.enabled`, our library MUST intercept
-incoming requests for `stormpath.web.register.uri`.
+incoming requests for `stormpath.web.register.path`.
 
 GET requests must respond in one of the following ways:
 
@@ -62,8 +62,8 @@ stormpath:
   web:
     register:
       enabled: true
-      uri: "/register"
-      nextUri: "/"
+      path: "/register"
+      nextPath: "/"
       autoLogin: false
       # autoLogin is possible only if the email verification feature is disabled
       # on the default default account store of the defined Stormpath
@@ -129,18 +129,18 @@ stormpath:
 Default: `true`
 
 This determines if the integration will handle the registration route, defined
-by `stormpath.web.registration.uri`
+by `stormpath.web.registration.path`
 
 
-#### <a name="uri"></a> uri
+#### <a name="path"></a> path
 
 Default: `/register`
 
-This URI that our integration should bind to for handling GET and POST requests
-for the `uri`.
+This path that our integration should bind to for handling GET and POST requests
+for the `path`.
 
 
-#### <a name="nextUri"></a> nextUri
+#### <a name="nextPath"></a> nextPath
 
 Default: `/`
 
@@ -151,7 +151,7 @@ is `True`.
 #### <a name="autoLogin"></a> autoLogin
 
 If enabled, the user should be automatically logged in and redirected to the
-`nextUri` after a successful registration.  This is only possible if the
+`nextPath` after a successful registration.  This is only possible if the
 default account store for the application has the email verification workflow
 disabled.
 
@@ -388,13 +388,13 @@ Content-Type: application/json; charset=utf-8
 * If the request is `Accept: text/html`, and..
   * The newly created account's status is ENABLED and [autoLogin](#autoLogin)
     is:
-    * `True`: issue a 302 Redirect to the `nextUri` and log the user in (create
+    * `True`: issue a 302 Redirect to the `nextPath` and log the user in (create
       the OAuth2 token cookies).
-    * `False`: 302 redirect the user to `stormpath.web.login.uri`, and append
+    * `False`: 302 redirect the user to `stormpath.web.login.path`, and append
       the query parameter `?status=created` (see [login page status messages][]).
 
   * The newly created account status is UNVERIFIED, then 302 redirect the user
-    to `stormpath.web.login.uri` and append the query parameter
+    to `stormpath.web.login.path` and append the query parameter
     `?status=unverified` (see [login page status messages][]).
 
 <a href="#top">Back to Top</a>

--- a/social.md
+++ b/social.md
@@ -20,7 +20,7 @@ describe in detail:
 
 In this situation, the user leaves your login page by redirect and is taken to
 the provider for authentication.  Once authentication is complete, the user is
-redirected back to a "callback" URI on your website.  This callback will provide
+redirected back to a "callback" path on your website.  This callback will provide
 an access token or access code as a query parameter.  You server uses a
 confidential keypair of the provider to validate the token/code, then retrieves
 the account data of the authenticated user.
@@ -89,7 +89,7 @@ callback handler must complete the following tasks:
   * Create or update the account in Stormpath, by making a call to the
     `application.getAccount()` method in the SDK of the framework language
   * Create the OAuth2 token cookies for the user
-  * Redirect the user to `stormpath.web.login.nextUri`
+  * Redirect the user to `stormpath.web.login.nextPath`
 
 If any of these tasks fail, an error should be immediately rendered to the user
 and the next task should not be attempted.

--- a/user-context.md
+++ b/user-context.md
@@ -10,14 +10,14 @@ environment.
 
 ### Configuration Options
 
-This route is enabled by default at the `/me` uri, but this endpoint can be
+This route is enabled by default at the `/me` path, but this endpoint can be
 changed or disabled entirely with these options:
 
 ```yaml
 web:
   me:
     enabled: true
-    uri: "/me"
+    path: "/me"
 ```
 
 ### Endpoint Response

--- a/web-config.yaml
+++ b/web-config.yaml
@@ -5,7 +5,7 @@ stormpath:
 
     oauth2:
       enabled: true
-      uri: "/oauth/token"
+      path: "/oauth/token"
       client_credentials:
         enabled: true
         accessToken:
@@ -23,7 +23,7 @@ stormpath:
     accessTokenCookie:
       name: "access_token"
       httpOnly: true
-      
+
       # See cookie-authentication.md for explanation of
       # how `null` values behave for these properties.
       secure: null
@@ -33,7 +33,7 @@ stormpath:
     refreshTokenCookie:
       name: "refresh_token"
       httpOnly: true
-      
+
       # See cookie-authentication.md for explanation of
       # how `null` values behave for these properties.
       secure: null
@@ -50,8 +50,8 @@ stormpath:
 
     register:
       enabled: true
-      uri: "/register"
-      nextUri: "/"
+      path: "/register"
+      nextPath: "/"
       # autoLogin is possible only if the email verification feature is disabled
       # on the default default account store of the defined Stormpath
       # application.
@@ -116,14 +116,14 @@ stormpath:
     # workflow enabled.
     verifyEmail:
       enabled: null
-      uri: "/verify"
-      nextUri: "/login"
+      path: "/verify"
+      nextPath: "/login"
       view: "verify"
 
     login:
       enabled: true
-      uri: "/login"
-      nextUri: "/"
+      path: "/login"
+      nextPath: "/"
       view: "login"
       form:
         fields:
@@ -145,17 +145,17 @@ stormpath:
 
     logout:
       enabled: true
-      uri: "/logout"
-      nextUri: "/"
+      path: "/logout"
+      nextPath: "/"
 
     # Unless forgotPassword.enabled is explicitly set to false, this feature
     # will be automatically enabled if the default account store for the defined
     # Stormpath application has the password reset workflow enabled.
     forgotPassword:
       enabled: null
-      uri: "/forgot"
+      path: "/forgot"
       view: "forgot-password"
-      nextUri: "/login?status=forgot"
+      nextPath: "/login?status=forgot"
 
     # Unless changePassword.enabled is explicitly set to false, this feature
     # will be automatically enabled if the default account store for the defined
@@ -163,20 +163,20 @@ stormpath:
     changePassword:
       enabled: null
       autoLogin: false
-      uri: "/change"
-      nextUri: "/login?status=reset"
+      path: "/change"
+      nextPath: "/login?status=reset"
       view: "change-password"
-      errorUri: "/forgot?status=invalid_sptoken"
+      errorPath: "/forgot?status=invalid_sptoken"
 
     # If idSite.enabled is true, the user should be redirected to ID site for
     # login, registration, and password reset.
     idSite:
       enabled: false
-      uri: "/idSiteResult"
-      nextUri: "/"
-      loginUri: ""
-      forgotUri: "/#/forgot"
-      registerUri: "/#/register"
+      path: "/idSiteResult"
+      nextPath: "/"
+      loginPath: ""
+      forgotPath: "/#/forgot"
+      registerPath: "/#/register"
 
     socialProviders:
       callbackRoot: "/callbacks"
@@ -185,7 +185,7 @@ stormpath:
     # the current user object
     me:
       enabled: true
-      uri: "/me"
+      path: "/me"
 
     # If the developer wants our integration to serve their Single Page
     # Application (SPA) in response to HTML requests for our default routes,


### PR DESCRIPTION
To remove confusion we should change the general use of `uri` to `path`. Since it's actually paths that we expect and not [URIs](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier).

For example, take this line of code from [`express-stormpath`](https://github.com/stormpath/express-stormpath/blob/master/lib/controllers/id-site-redirect.js#L17):

``` javascript
var cbUri = req.protocol + '://' + req.get('host') + config.web.idSite.uri;
```

From looking at this, I'd expect it to build a URL that would look something like:

`http://localhosthttp://localhost/idSiteResult`

But since `config.web.idSite.uri` is a path, the actual result is:

`http://localhost/idSiteResult`

So to not create confusion, my suggestion is that we change this. And in order not to introduce any breaking changes, we add a pre-processing step to the configuration builder/loader where we automatically translate all the changed `uri` and `*Uri` configs to `path` and `*Path`.
