### PR TITLE
Describe how social login callback errors should be displayed

### DIFF
--- a/social.md
+++ b/social.md
@@ -94,6 +94,9 @@ callback handler must complete the following tasks:
 If any of these tasks fail, an error should be immediately rendered to the user
 and the next task should not be attempted.
 
+The error should be displayed on the login form in the same way other login
+errors are shown.
+
 ## Implementing Popup-Based Workflows
 
 Single-page applications will need to query the server to determine which social


### PR DESCRIPTION
This PR adds a paragraph about how OAuth/Social Login callback errors should be displayed for the end user.

This behaviour was implemented into the `express-stormpath` SDK with the following PR: https://github.com/stormpath/express-stormpath/pull/304
