### PR TITLE
Re-define social callback URIs, add scope options

### DIFF
--- a/social.md
+++ b/social.md
@@ -76,7 +76,7 @@ The library must implement provider callbacks for all social provider
 directories that are mapped to the specified Stormpath application.  The
 callback URLs for each provider should take the form of:
 
-> `/<stormpath.web.socialProviders.callbackRoot>/<providerId>`
+> `<stormpath.web.socialProviders.[providerId].callbackUri>/<providerId>`
 
 Where `providerId` is the property that is found in the `provider` object of
 the Stormpath directory, e.g. `google` or `facebook`.

--- a/social.md
+++ b/social.md
@@ -76,7 +76,7 @@ The library must implement provider callbacks for all social provider
 directories that are mapped to the specified Stormpath application.  The
 callback URLs for each provider should take the form of:
 
-> `<stormpath.web.socialProviders.[providerId].callbackUri>/<providerId>`
+> `<stormpath.web.social.[providerId].uri>/<providerId>`
 
 Where `providerId` is the property that is found in the `provider` object of
 the Stormpath directory, e.g. `google` or `facebook`.

--- a/web-config.yaml
+++ b/web-config.yaml
@@ -184,8 +184,24 @@ stormpath:
       forgotUri: "/#/forgot"
       registerUri: "/#/register"
 
+
+    # Social provider configuration.  This defines the callback URIs for OAuth
+    # flows, and the scope that is requested of each provider.  These settings
+    # have no affect if the application does not have an account store for the
+    # given provider.
+
     socialProviders:
-      callbackRoot: "/callbacks"
+      facebook:
+        callbackUri: "/callbacks/facebook"
+        scope: "email"
+      github:
+        callbackUri: "/callbacks/github"
+        scope: "user:email"
+      google:
+        callbackUri: "/callbacks/google"
+        scope: "email profile"
+      linkedin:
+        callbackUri: "/callbacks/linkedin"
 
     # The /me route is for front-end applications, it returns a JSON object with
     # the current user object.  The developer can opt-in to expanding account

--- a/web-config.yaml
+++ b/web-config.yaml
@@ -185,12 +185,15 @@ stormpath:
       registerUri: "/#/register"
 
 
-    # Social provider configuration.  This defines the callback URIs for OAuth
-    # flows, and the scope that is requested of each provider.  These settings
-    # have no affect if the application does not have an account store for the
-    # given provider.
+    # Social login configuration.  This defines the callback URIs for OAuth
+    # flows, and the scope that is requested of each provider.  Some providers
+    # want space-separated scopes, some want comma-separated.  As such, these
+    # string values should be passed directly, as defined.
+    #
+    # These settings have no affect if the application does not have an account
+    # store for the given provider.
 
-    socialProviders:
+    social:
       facebook:
         callbackUri: "/callbacks/facebook"
         scope: "email"

--- a/web-config.yaml
+++ b/web-config.yaml
@@ -195,16 +195,16 @@ stormpath:
 
     social:
       facebook:
-        callbackUri: "/callbacks/facebook"
+        uri: "/callbacks/facebook"
         scope: "email"
       github:
-        callbackUri: "/callbacks/github"
+        uri: "/callbacks/github"
         scope: "user:email"
       google:
-        callbackUri: "/callbacks/google"
+        uri: "/callbacks/google"
         scope: "email profile"
       linkedin:
-        callbackUri: "/callbacks/linkedin"
+        uri: "/callbacks/linkedin"
 
     # The /me route is for front-end applications, it returns a JSON object with
     # the current user object.  The developer can opt-in to expanding account


### PR DESCRIPTION
For discussion.  I realized that we weren't capturing the scope options, and as such I think the callback uris can be better structured.
