### PR TITLE
Should not append /<providerId> to social callback URIs

### DIFF
--- a/social.md
+++ b/social.md
@@ -76,7 +76,7 @@ The library must implement provider callbacks for all social provider
 directories that are mapped to the specified Stormpath application.  The
 callback URLs for each provider should take the form of:
 
-> `<stormpath.web.social.[providerId].uri>/<providerId>`
+> `<stormpath.web.social.[providerId].uri>`
 
 Where `providerId` is the property that is found in the `provider` object of
 the Stormpath directory, e.g. `google` or `facebook`.


### PR DESCRIPTION
I think we missed a thing in the spec. This is what [social.md](https://github.com/stormpath/stormpath-framework-spec/blob/master/social.md#implementing-page-based-workflows) defines how the callbacks should be built:

> `<stormpath.web.social.[providerId].uri>/<providerId>`

But in [web-config.yaml](https://github.com/stormpath/stormpath-framework-spec/blob/master/web-config.yaml#L196-L207) the URIs are hardcoded to e.g. `/callbacks/facebook`. If we would build the URI according to the spec, it would look like this:

> /callbacks/facebook/facebook

This PR removes the trailing `/<providerId>` from the social URI callback specification. If this is not correct, close this PR and let me know.
