### PR TITLE
Updates to expansion options

### DIFF
--- a/user-context.md
+++ b/user-context.md
@@ -4,9 +4,9 @@ This support is for front-end clients such as AngularJs.  This endpoint allows
 the front-end application to fetch the account object of the currently
 authenticated user.
 
-We must provide this endpoint because, for security reasons, we store our
-access tokens in `HttpOnly` cookies which cannot be read by the JavaScript
-environment.
+We must provide this endpoint because, for security reasons, we don't allow the
+client to store any information about the user.  It must be fetched from the
+server at runtime.
 
 ### Configuration Options
 
@@ -24,8 +24,11 @@ web:
 
 This endpoint should always respond with `Content-Type: application/json`, and
 the body should be the JSON representation of the currently authenticated user.
-By default it should not expand any of the account's linked resources.  However
-the developer can opt-in to expansion through configuration (see next section).
+
+
+By default, all linked resources should be removed from the object.  However the
+developer can opt-in to expansion through configuration (see next section). In
+this situation the linked resource can be returned.
 
 This endpoint must always send the following headers, so that the browser does
 not cache this response:
@@ -35,7 +38,7 @@ Cache-Control: no-cache, no-store
 Pragma: no-cache
 ```
 
-Example response body:
+Example default response body:
 
 ```json
 {
@@ -49,39 +52,14 @@ Example response body:
   "status": "ENABLED",
   "createdAt": "2014-04-07T16:38:44.000Z",
   "modifiedAt": "2014-08-28T22:35:10.000Z",
-  "emailVerificationToken": null,
-  "customData": {
-    "href": "https://api.stormpath.com/v1/accounts/xxx/customData"
-  },
-  "providerData": {
-    "href": "https://api.stormpath.com/v1/accounts/xxx/providerData"
-  },
-  "directory": {
-    "href": "https://api.stormpath.com/v1/directories/xxx"
-  },
-  "tenant": {
-    "href": "https://api.stormpath.com/v1/tenants/xxx"
-  },
-  "groups": {
-    "href": "https://api.stormpath.com/v1/accounts/xxx/groups"
-  },
-  "applications": {
-    "href": "https://api.stormpath.com/v1/accounts/xxx/applications"
-  },
-  "groupMemberships": {
-    "href": "https://api.stormpath.com/v1/accounts/xxx/groupMemberships"
-  },
-  "apiKeys": {
-    "href": "https://api.stormpath.com/v1/accounts/xxx/apiKeys"
-  }
+  "emailVerificationToken": null
 }
 ```
 
 ### Expansion Options
 
-The developer can opt-in to expanding the account's linked resources.  At the
-moment this is used by our AngularJS clients, so that the front-end can know
-what groups a user is a member of.  For example:
+The developer can opt-in to expanding the account's linked resources, for
+example:
 
 ```yaml
 stormpath:

--- a/web-config.yaml
+++ b/web-config.yaml
@@ -14,18 +14,6 @@ stormpath:
         enabled: true
         validationStrategy: "local"
 
-    # These options are use to "automatically" expand an account's linked
-    # resources (customData, groups) before providing the account context to the
-    # deverloper.  This is a conveneince for the developer, so that these
-    # resources are pre-warmed in the local cache.  This setting must not affect
-    # any respones from the framework, this is internal conveneince only.
-
-    expand:
-      apiKeys: false
-      customData: false
-      directory: false
-      groups: false
-
     accessTokenCookie:
       name: "access_token"
       httpOnly: true
@@ -216,9 +204,13 @@ stormpath:
       uri: "/me"
       expand:
         apiKeys: false
+        applications: false
         customData: false
         directory: false
+        groupMemberships: false
         groups: false
+        providerData: false
+        tenant: false
 
     # If the developer wants our integration to serve their Single Page
     # Application (SPA) in response to HTML requests for our default routes,


### PR DESCRIPTION
- Removing expansion options from the spec, as this optimization can be pushed down to the SDK
- /me should not populate linked resources unless they are explicitly expanded through configuration of `stormpath.web.me.expand`
