### PR TITLE
ID Site

### DIFF
--- a/idsite.md
+++ b/idsite.md
@@ -1,0 +1,41 @@
+# ID Site
+
+Framework integrations must implement the `web.idSite.enabled` behavior. 
+
+ID Site is used as a replacement for the `/login`, `/logout`, `/forgot`, and `/register` pages, which will redirect to ID Site instead of performing their default behavior. 
+
+In addition, enabling ID Site in the configuration enables an `/idSiteResult` endpoint. 
+
+# `/idSiteResult`
+
+## Request Types
+
+* GET
+
+## Content Type
+
+* Any
+
+## Parameters
+
+`jwtResponse` - a [Stormpath JWT](http://docs.stormpath.com/guides/using-id-site/#handling-the-callback-to-your-application-from-id-site). This should be handled using the underlying SDK's Stormpath Token authenticator. 
+
+## Response
+
+The `jwtResponse` from ID Site can have three states, with the following response logic: 
+
+**REGISTERED**
+
+A new user was created. Follow the standard post-registration logic (like redirecting to the login page or autologin). 
+
+**AUTHENTICATED**
+
+A user logged in. Follow the standard login logic (like setting cookies, and redirecting the user)
+
+**LOGOUT**
+
+A user logged out. Follow the standard logout logic.
+
+## Errors
+
+If not a valid Stormpath JWT, render a `text/html`401 Unauthorized` error. 

--- a/idsite.md
+++ b/idsite.md
@@ -2,14 +2,14 @@
 
 ID Site is a hosted login & registration application that simplifies single-sign on (SSO) flows by providing a common place for redirects and cookie storage. If the developer has chosen to use ID Site, they likely have multiple Stormpath Applications that are redirecting the user to ID Site for authentication. When the user authenticates at ID Site, they are returned to the original application (service provider, AKA the SP) with Stormpath Assertion JWT. The application can verify this token and resolve the account that has authenticated.
 
-If the developer needs to use ID Site, they will enable it with `stormpath.web.idSite.enabled`. When this value is true, we should redirect the user to ID site when the following URIs are accessed with a GET request:
+If the developer needs to use ID Site, they will enable it with `stormpath.web.idSite.enabled`. When this value is true, we should redirect the user to ID Site when the following URIs are accessed with a GET request:
 
-* `stormpath.web.login.uri`
+* `stormpath.web.login.uri` - with a path of `stormpath.web.idSite.loginUri`
 * `stormpath.web.logout.uri`
-* `stormpath.web.register.uri`
-* `stormpath.web.forgot.uri`
+* `stormpath.web.register.uri` - with a path of `stormpath.web.idSite.registerUri`
+* `stormpath.web.forgot.uri` - with a path of `stormpath.web.idSite.forgotUri`
 
-In addition, enabling ID Site in the configuration enables an `/idSiteResult` endpoint. 
+In addition, enabling ID Site enables an `/idSiteResult` endpoint, configurable via `stormpath.web.idSite.uri`. 
 
 # `/idSiteResult`
 
@@ -19,7 +19,7 @@ In addition, enabling ID Site in the configuration enables an `/idSiteResult` en
 
 ## Content Type
 
-* Any
+* Any - always follows `text/html` logic.
 
 ## Parameters
 
@@ -31,15 +31,15 @@ The `jwtResponse` from ID Site can have three states, with the following respons
 
 **REGISTERED**
 
-A new user was created. Follow the standard post-registration logic (like redirecting to the login page or autologin). 
+A new user was created. Follow the standard [post registration logic](registration.md#-post-response-handling) (like redirecting to the login page or autologin). 
 
 **AUTHENTICATED**
 
-A user logged in. Follow the standard login logic (like setting cookies, and redirecting the user)
+A user logged in. Follow the standard [post login logic](login.md#-post-response-handling) (like setting cookies, and redirecting the user)
 
 **LOGOUT**
 
-A user logged out. Follow the standard logout logic.
+A user logged out. Follow the standard [post logout logic](logout.md).
 
 ## Errors
 

--- a/idsite.md
+++ b/idsite.md
@@ -1,8 +1,13 @@
 # ID Site
 
-Framework integrations must implement the `web.idSite.enabled` behavior. 
+ID Site is a hosted login & registration application that simplifies single-sign on (SSO) flows by providing a common place for redirects and cookie storage. If the developer has chosen to use ID Site, they likely have multiple Stormpath Applications that are redirecting the user to ID Site for authentication. When the user authenticates at ID Site, they are returned to the original application (service provider, AKA the SP) with Stormpath Assertion JWT. The application can verify this token and resolve the account that has authenticated.
 
-ID Site is used as a replacement for the `/login`, `/logout`, `/forgot`, and `/register` pages, which will redirect to ID Site instead of performing their default behavior. 
+If the developer needs to use ID Site, they will enable it with `stormpath.web.idSite.enabled`. When this value is true, we should redirect the user to ID site when the following URIs are accessed with a GET request:
+
+* `stormpath.web.login.uri`
+* `stormpath.web.logout.uri`
+* `stormpath.web.register.uri`
+* `stormpath.web.forgot.uri`
 
 In addition, enabling ID Site in the configuration enables an `/idSiteResult` endpoint. 
 

--- a/idsite.md
+++ b/idsite.md
@@ -43,4 +43,4 @@ A user logged out. Follow the standard logout logic.
 
 ## Errors
 
-If not a valid Stormpath JWT, render a `text/html`401 Unauthorized` error. 
+If not a valid Stormpath JWT, render a `text/html` 401 Unauthorized` error. 

--- a/idsite.md
+++ b/idsite.md
@@ -9,9 +9,9 @@ If the developer needs to use ID Site, they will enable it with `stormpath.web.i
 * `stormpath.web.register.uri` - with a path of `stormpath.web.idSite.registerUri`
 * `stormpath.web.forgot.uri` - with a path of `stormpath.web.idSite.forgotUri`
 
-In addition, enabling ID Site enables an `/idSiteResult` endpoint, configurable via `stormpath.web.idSite.uri`. 
+In addition, enabling ID Site enables an `/callbacks/stormpath` endpoint, configurable via `stormpath.web.idSite.uri`. 
 
-# `/idSiteResult`
+# `/callbacks/stormpath`
 
 ## Request Types
 

--- a/idsite.md
+++ b/idsite.md
@@ -2,16 +2,26 @@
 
 ID Site is a hosted login & registration application that simplifies single-sign on (SSO) flows by providing a common place for redirects and cookie storage. If the developer has chosen to use ID Site, they likely have multiple Stormpath Applications that are redirecting the user to ID Site for authentication. When the user authenticates at ID Site, they are returned to the original application (service provider, AKA the SP) with Stormpath Assertion JWT. The application can verify this token and resolve the account that has authenticated.
 
-If the developer needs to use ID Site, they will enable it with `stormpath.web.idSite.enabled`. When this value is true, we should redirect the user to ID Site when the following URIs are accessed with a GET request:
+If the developer needs to use ID Site, they will enable it with `stormpath.web.idSite.enabled`. `stormpath.web.callback.enabled` must also be true, otherwise the integration should throw an error. 
+
+When ID Site is enabled, we should redirect the user to ID Site when the following URIs are accessed with a GET request:
 
 * `stormpath.web.login.uri` - with a path of `stormpath.web.idSite.loginUri`
 * `stormpath.web.logout.uri`
 * `stormpath.web.register.uri` - with a path of `stormpath.web.idSite.registerUri`
 * `stormpath.web.forgot.uri` - with a path of `stormpath.web.idSite.forgotUri`
 
-In addition, enabling ID Site enables an `/callbacks/stormpath` endpoint, configurable via `stormpath.web.idSite.uri`. 
+In addition, ID Site needs `stormpath.web.callback.enabled` to be true, so we can pass back the Stormpath assertion JWT. 
 
-# `/callbacks/stormpath`
+# `/stormpathCallback`
+
+A callback so Stormpath can pass information to the web application. This is currently being used for ID Site, but may be used in the future for SAML, Stormpath handled social login, webhooks, and other messages from Stormpath. 
+
+## Configuration
+
+    callback: 
+      enabled: true
+      uri: "/stormpathCallback"
 
 ## Request Types
 

--- a/password-reset.md
+++ b/password-reset.md
@@ -88,6 +88,8 @@ Default: `/forgot`
 The URI that we'll attach an interceptor to for requests, if `enabled` is
 `true`.
 
+If `stormpath.web.idSite.enabled` is `true`, redirect the user idSite using the ID Site URL Builder in the SDK.
+
 <a href="#top">Back to Top</a>
 
 

--- a/registration.md
+++ b/registration.md
@@ -15,6 +15,9 @@ GET requests may:
 
 * Serve the dynamic registration JSON view model.
 
+* Redirect the user to ID Site if `stormpath.web.idSite.enabled` is `true`. This
+  should be done with the ID Site URL Builder in the SDK.
+
 * Pass on the request.
 
 POST requests may:

--- a/web-config.yaml
+++ b/web-config.yaml
@@ -171,7 +171,7 @@ stormpath:
     # through ID Site on logout.
     idSite:
       enabled: false
-      uri: "/idSiteResult"
+      uri: "/callbacks/stormpath"
       loginUri: ""
       forgotUri: "/#/forgot"
       registerUri: "/#/register"

--- a/web-config.yaml
+++ b/web-config.yaml
@@ -172,7 +172,6 @@ stormpath:
     idSite:
       enabled: false
       uri: "/idSiteResult"
-      nextUri: "/"
       loginUri: ""
       forgotUri: "/#/forgot"
       registerUri: "/#/register"

--- a/web-config.yaml
+++ b/web-config.yaml
@@ -171,10 +171,16 @@ stormpath:
     # through ID Site on logout.
     idSite:
       enabled: false
-      uri: "/callbacks/stormpath"
       loginUri: ""
       forgotUri: "/#/forgot"
       registerUri: "/#/register"
+
+    # A callback so Stormpath can pass information to the web application. This is
+    # currently being used for ID Site, but may be used in the future for SAML,
+    # Stormpath handled social login, webhooks, and other messages from Stormpath. 
+    callback: 
+      enabled: true
+      uri: "/stormpathCallback"
 
     # Social login configuration.  This defines the callback URIs for OAuth
     # flows, and the scope that is requested of each provider.  Some providers


### PR DESCRIPTION
Fixes #73. Documents what we currently do.

The only potentially controversial change is that I removed the `web.idSite.nextUri` configuration setting. This is because ID Site only works if `/register`, `/login`, etc endpoints are enabled in the configuration. As a result I think it makes more sense that it would respect the `nextUri` settings of those parts of the configuration. 
