### PR TITLE
Multi Tenancy concerns

### DIFF
--- a/example-config.yaml
+++ b/example-config.yaml
@@ -14,20 +14,14 @@ stormpath:
       # When enabled, the framework will require the user to authenticate against
       # a specific Organization.  The authenticated organization is persisted in
       # the access token that is issued.
+      #
+      # At the moment we only support a sub-domain based strategy, wherby the
+      # user must arrive on the subdomain that correlates with their tenant in
+      # order to authenticate.  If they visit the parent domain, they will be
+      # required to identify the organization they wish to use.
 
       enabled: false
-
-      # If useSubdomain=true, we attempt to resolve the organization context by
-      # looking at the subdomain, e.g. org-a.example.com.  Otherwise we will
-      # render a form field that requires the user to enter this value.  This
-      # automatic behavior can be disabled by explicitly disabling those form
-      # fields (see below).
-      #
-      # When useSubdomain is true, and the user is authenticating with an access
-      # token that contains an organization, we assert that this is the same
-      # organization that is identified by the subdomain.
-
-      useSubdomain: true
+      strategy: "subdomain"
 
 
     oauth2:
@@ -209,6 +203,18 @@ stormpath:
       enabled: true
       uri: "/logout"
       nextUri: "/"
+
+    # If using subdoain multi-tenancy, this form is shown on the parent domain
+    # when organization context is unkonwn.  Configuration of this form is limited
+    # to label, placeholder and view template location.
+
+    organizationSelect:
+      view: "organization-select"
+      form:
+        fields:
+          organizationNameKey:
+            label: "Enter your organization name to continue"
+            placeholder: "e.g. my-company"
 
     # Unless forgotPassword.enabled is explicitly set to false, this feature
     # will be automatically enabled if the default account store for the defined

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -87,9 +87,10 @@ stormpath:
       autoLogin: false
       form:
         fields:
-          # Unless specifically set to false, the organizationNameKey field will
-          # automatically be shown when stormpath.web.multiTenancy.enabled=true,
-          # and an organization cannot be resolved.
+          # This field will be shown as the only field if the user is visiting
+          # the parent domain of a sub-domain based multi-tenant configuration.
+          # The user will be redirected to the correct subdomain to finish the
+          # workflow.
           organizationNameKey:
             enabled: null
             visible: true
@@ -174,9 +175,10 @@ stormpath:
       view: "login"
       form:
         fields:
-          # Unless specifically set to false, the organizationNameKey field will
-          # automatically be shown when stormpath.web.multiTenancy.enabled=true,
-          # and an organization cannot be resolved.
+          # This field will be shown as the only field if the user is visiting
+          # the parent domain of a sub-domain based multi-tenant configuration.
+          # The user will be redirected to the correct subdomain to finish the
+          # workflow.
           organizationNameKey:
             enabled: null
             visible: true

--- a/multi-tenancy.md
+++ b/multi-tenancy.md
@@ -14,11 +14,12 @@ The following design guidelines must be followed when adding multi-tenancy featu
 
 * The resolution should be achieved with a "Organization Resolver".  The developer should be able to provide their own resolver, but our framework should provide a default resolver.  The point of this resolver is to provide our view controllers with the organization to be use with REST API requests.
 
-* The default resolver should have the following characteristics:
+* The default resolver must have the following characteristics:
 
     - It receives a HTTP request for inspection
     - It returns an Organization if one can be resolved from the request context.
     - It should only return an Organization that is mapped to the configured application.
+    - It attaches the resolved Organization to the request, so that the developer can make use of this context.
     
 * The default resolver should follow this procedure to determine the organization:
 
@@ -31,14 +32,12 @@ The following design guidelines must be followed when adding multi-tenancy featu
 * If the user visits the root domain to specify organization context, the form should only show the organization name key field.  The user must enter a valid organization name key.  An error is shown if the org is not valid.  If the org is valid we redirect them to the same view on the correct subdomain.
 
 * When processing a email verification request:
-    - If the key has expired or cannot be found, and an organization cannot be resolved, redirect the user to `<baseDomain>/verify`, and render a field that allows them to specify their organization name.
-    - If the key is valid, the REST API response needs to include the organization name key on the response, so that we can redirect the user to `<orgNameKey>.<baseDomain><verifyEmail.nextUri|login.nextUri>` - *REQUIRES REST API CHANGE*
+    - If the key has expired or cannot be found, and an organization cannot be resolved, redirect the user to `<stormpath.web.domainName>/verify`, and render a field that allows them to specify their organization name.
+    - If the key is valid, the REST API response needs to include the organization name key on the response, so that we can redirect the user to `<orgNameKey>.<stormpath.web.domainName><stormpath.web.verifyEmail.nextUri|login.nextUri>` - *REQUIRES REST API CHANGE*
 
 * When processing a password reset request:
-    - If the key has expired or cannot be found, and an organization cannot be resolved, redirect the user to `<baseDomain>/forgot`, and render a field that allows them to specify their organization name.
-    - If the key is valid, the REST API response needs to include the organization name key on the response, so that we can redirect the user to `<orgNameKey>.<baseDomain><changePassword.nextUri|login.nextUri>` - *REQUIRES REST API CHANGE*
-    
-* The framework should provide a convenience the allows the developer to know the authenticated organization of an authenticated request.  This should be done by looking at the `org` claim of the access token that was used to authenticate the request.
+    - If the key has expired or cannot be found, and an organization cannot be resolved, redirect the user to `<stormpath.web.domainName>/forgot`, and render a field that allows them to specify their organization name.
+    - If the key is valid, the REST API response needs to include the organization name key on the response, so that we can redirect the user to `<orgNameKey>.<stormpath.web.domainName><stormpath.web.changePassword.nextUri|stormpath.web.login.nextUri>` - *REQUIRES REST API CHANGE*
 
 ## Future Use Cases
 


### PR DESCRIPTION
Here are some issues I ran into while trying to implement our current spec in Express:

* We had a note about sending a 401 if the `org` of the token is not the same as the subdomian, and that the default org resolver should do this, but this is mixing authorization concerns in with organization resolution concerns.  I'm removing this, the developer can use the org context to make their own authorization decisions.
 
* The "what happens if they visit the parent domain, without org context" story isn't well defined.  Per our discussion on 11/3, I've updated the spec to reflect our decision: the root domain requires you to provide an organization name key as the only form field, if the submitted key is valid, we redirect you to the same view on the subdomain of the organization.
